### PR TITLE
set the cursor position after interaction with truth blocks

### DIFF
--- a/src/truths/truth-block.ts
+++ b/src/truths/truth-block.ts
@@ -227,6 +227,8 @@ class TruthRenderer extends MarkdownRenderChild {
       editorRange.from,
       to,
     );
+    editor.focus();
+    editor.setCursor({ ch: 0, line: to.line + 2 });
   }
 
   reset() {
@@ -256,6 +258,8 @@ class TruthRenderer extends MarkdownRenderChild {
       editorRange.from,
       to,
     );
+    editor.focus();
+    editor.setCursor({ ch: 0, line: to.line + 2 });
   }
 }
 


### PR DESCRIPTION
This makes things less jumpy and sets you up to start typing right away.