### PR TITLE
use smart quotes for callsigns to avoid Windows filename issue

### DIFF
--- a/src/entity/specs.ts
+++ b/src/entity/specs.ts
@@ -56,7 +56,10 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
     collectionId: "starforged/collections/oracles/characters",
     label: "Character",
     nameGen: (ent) =>
-      `${ent.givenName[0]?.simpleResult}${ent.callSign.length > 0 ? ' "' + ent.callSign[0].simpleResult + '"' : ""} ${ent.familyName[0]?.simpleResult}`,
+      // NB(@zkat): We use smart quotes here because `"` is an invalid
+      // character in Windows filenames and `'` looks like shit. They look
+      // nice anyway.
+      `${ent.givenName[0]?.simpleResult}${ent.callSign.length > 0 ? " “" + ent.callSign[0].simpleResult + "”" : ""} ${ent.familyName[0]?.simpleResult}`,
     spec: {
       givenName: {
         id: "starforged/oracles/characters/name/given",


### PR DESCRIPTION
Fixes: https://github.com/iron-vault-plugin/iron-vault/issues/204