### PR TITLE
Add `pnpm install` to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Release](https://github.com/iron-vault-plugin/iron-vault/releases/latest). You'l
 to put `main.js`, `manifest.json`, and `styles.css` in
 `your-vault/.obsidian/plugins/iron-vault`.
 
-To build the code and copy it to your vault yourself, run `pnpm build` to
+To build the code and copy it to your vault yourself, run `pnpm install` and `pnpm build` to
 generate the production files, which will be in the repo root. You can then
 copy these to the location above.
 


### PR DESCRIPTION
I needed to run `pnpm install` before 'pnpm build`. Added to README.md in case this applies to everyone. ~Ars