### PR TITLE
Give asset meters unique keys and labels

### DIFF
--- a/src/characters/action-context.ts
+++ b/src/characters/action-context.ts
@@ -138,14 +138,7 @@ export class CharacterActionContext implements IActionContext {
 
   get conditionMeters(): MeterWithLens<ConditionMeterDefinition>[] {
     const { character, lens } = this.characterContext;
-    return Object.values(meterLenses(lens, character, this)).map(
-      ({ key, definition, lens }) => ({
-        key,
-        definition,
-        lens,
-        value: lens.get(character),
-      }),
-    );
+    return meterLenses(lens, character, this);
   }
 
   async update(

--- a/src/characters/assets.ts
+++ b/src/characters/assets.ts
@@ -252,14 +252,15 @@ export function assetMeters(
 
   return meters.map(([key, control]) => {
     return {
-      key,
-      definition: {
-        kind: "condition_meter",
+      key: `${asset._id}@${key}`,
+      definition: new ConditionMeterDefinition({
         label: control.label,
         min: control.min,
         max: control.max,
         rollable: control.rollable,
-      },
+        value: control.value,
+      }),
+      parent: { label: asset.name },
       lens: {
         get(source) {
           const assets = charLens.assets.get(source);

--- a/src/characters/display.ts
+++ b/src/characters/display.ts
@@ -1,0 +1,13 @@
+import { MeterCommon } from "rules/ruleset";
+import { capitalize } from "utils/strings";
+import { KeyWithDefinition } from "./lens";
+
+/** Get human readable name for meter, including parent asset when present. */
+export function labelForMeter<T extends MeterCommon>(
+  meter: KeyWithDefinition<T>,
+): string {
+  return (
+    (meter.parent ? `${meter.parent.label} / ` : "") +
+    capitalize(meter.definition.label)
+  );
+}

--- a/src/characters/meter-commands.ts
+++ b/src/characters/meter-commands.ts
@@ -13,6 +13,7 @@ import {
   determineCharacterActionContext,
   requireActiveCharacterContext,
 } from "./action-context";
+import { labelForMeter } from "./display";
 import { MeterWithLens, MeterWithoutLens, momentumOps } from "./lens";
 
 export async function burnMomentum(
@@ -66,7 +67,7 @@ export async function promptForMeter(
   const { value: meter } = await CustomSuggestModal.selectWithUserEntry(
     app,
     actionContext.conditionMeters.filter(meterFilter),
-    ({ definition }) => definition.label,
+    labelForMeter,
     (input, el) => {
       el.setText(`Use custom meter '${input}'`);
     },
@@ -114,7 +115,7 @@ export const modifyMeterCommand = async (
     | (Omit<MeterWithoutLens<ConditionMeterDefinition>, "value"> & {
         value: number;
       });
-  if (!choice.value) {
+  if (choice.value == null) {
     const value = await CustomSuggestModal.select(
       plugin.app,
       numberRange(choice.definition.min, choice.definition.max),
@@ -147,7 +148,7 @@ export const modifyMeterCommand = async (
   }
 
   const meterNode = node("meter", {
-    values: [measure.key],
+    values: [labelForMeter(measure)],
     properties: { from: measure.value, to: newValue },
   });
   updatePreviousMoveOrCreateBlock(

--- a/src/moves/action/index.ts
+++ b/src/moves/action/index.ts
@@ -4,6 +4,7 @@ import {
   CharacterActionContext,
   determineCharacterActionContext,
 } from "characters/action-context";
+import { labelForMeter } from "characters/display";
 import { AnyDataswornMove } from "datastore/datasworn-indexer";
 import IronVaultPlugin from "index";
 import { rootLogger } from "logger";
@@ -493,8 +494,9 @@ async function handleActionRoll(
   if (stat.key === SKIP_ROLL) return createEmptyMoveDescription(move);
 
   // This stat has an unknown value, so we need to prompt the user for a value.
-  if (!stat.value) {
-    stat.value = await CustomSuggestModal.select(
+  let statValue = stat.value;
+  if (statValue == null) {
+    statValue = await CustomSuggestModal.select(
       plugin.app,
       [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
       (n) => n.toString(10),
@@ -508,7 +510,7 @@ async function handleActionRoll(
   while (adds.length < 5) {
     const addValue = await CustomSuggestModal.select(
       plugin.app,
-      validAdds(stat.value ?? 0),
+      validAdds(statValue ?? 0),
       (n) => n.toString(10),
       undefined,
       `Choose an amount for the ${ORDINALS[adds.length + 1]} add.`,
@@ -555,8 +557,8 @@ async function handleActionRoll(
   let description = await processActionMove(
     plugin,
     move,
-    stat.key,
-    stat.value ?? 0,
+    labelForMeter(stat),
+    statValue,
     adds,
     rolls,
   );
@@ -636,7 +638,7 @@ async function promptForRollable(
     (m) =>
       m.key === SKIP_ROLL
         ? "Skip roll"
-        : `${m.definition.label}: ${m.value ?? "unknown"}`,
+        : `${labelForMeter(m)}: ${m.value ?? "unknown"}`,
     (input, el) => {
       el.setText(`Use custom meter '${input}'`);
     },

--- a/src/utils/ensure-unique.ts
+++ b/src/utils/ensure-unique.ts
@@ -1,0 +1,21 @@
+class DuplicateKeysError extends Error {}
+export function ensureUnique<T>(...seqs: Iterable<T>[]): void {
+  const seen = new Set<T>();
+  const duplicate = new Set<T>();
+
+  for (const seq of seqs) {
+    for (const elem of seq) {
+      if (seen.has(elem)) {
+        duplicate.add(elem);
+      } else {
+        seen.add(elem);
+      }
+    }
+  }
+
+  if (duplicate.size > 0) {
+    throw new DuplicateKeysError(
+      `expected unique keys, but following were duplicated: ${[...duplicate.keys()]}`,
+    );
+  }
+}

--- a/test-vault/characters/Ash Barlowe.md
+++ b/test-vault/characters/Ash Barlowe.md
@@ -50,6 +50,16 @@ assets:
     controls:
       broken: false
     options: {}
+  - id: asset:starforged/companion/protocol_bot
+    abilities:
+      - true
+      - false
+      - false
+    controls:
+      health: 2
+      health/out_of_action: false
+    options:
+      name: Jeeves
 spirit: 5
 supply: 4
 Quests_Progress: 4


### PR DESCRIPTION
This gives asset meters the label `<asset name> / <meter label>` in the meter lists, as well as in the mechanics node outputs.

It also fixes a bug I noticed where meters with a value of 0 would behave as if a value didn't exist (prompting you for a value, etc).

Fixes #362