### PR TITLE
Handle renames in tracked entity blocks

### DIFF
--- a/src/indexer/index-impl.ts
+++ b/src/indexer/index-impl.ts
@@ -79,11 +79,33 @@ export class IndexImpl<T, E extends Error> implements Index<T, E> {
     return this.#map[Symbol.toStringTag];
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on(name: "changed", callback: (path: string) => any, ctx?: any): EventRef;
+  rename(oldPath: string, newPath: string): boolean {
+    const previous = this.get(oldPath);
+    if (previous) {
+      this.#map.delete(oldPath);
+      this.#map.set(newPath, previous);
+      this.trigger("renamed", oldPath, newPath);
+      return true;
+    } else {
+      return false;
+    }
+  }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on(name: string, callback: (...data: any) => any, ctx?: any): EventRef {
+  on(
+    name: "changed",
+    callback: (path: string) => unknown,
+    ctx?: unknown,
+  ): EventRef;
+  on(
+    name: "renamed",
+    callback: (oldPath: string, newPath: string) => unknown,
+    ctx?: unknown,
+  ): EventRef;
+  on(
+    name: string,
+    callback: (...data: never[]) => unknown,
+    ctx?: unknown,
+  ): EventRef {
     return this.events.on(name, callback, ctx);
   }
 
@@ -96,9 +118,9 @@ export class IndexImpl<T, E extends Error> implements Index<T, E> {
     this.events.offref(ref);
   }
 
-  trigger(name: "changed", path: string): void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trigger(name: string, ...data: any[]): void {
+  protected trigger(name: "changed", path: string): void;
+  protected trigger(name: "renamed", oldPath: string, newPath: string): void;
+  protected trigger(name: string, ...data: never[]): void {
     this.events.trigger(name, ...data);
   }
 }

--- a/src/indexer/index-interface.ts
+++ b/src/indexer/index-interface.ts
@@ -4,8 +4,19 @@ import { Either } from "utils/either";
 export interface Index<T, E extends Error> extends Map<string, Either<E, T>> {
   readonly ofValid: ReadonlyMap<string, T>;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on(name: "changed", callback: (path: string) => any, ctx?: any): EventRef;
+  /** Rename the old key to the new key, returning true if old key was found. */
+  rename(oldPath: string, newPath: string): boolean;
+
+  on(
+    name: "changed",
+    callback: (path: string) => unknown,
+    ctx?: unknown,
+  ): EventRef;
+  on(
+    name: "renamed",
+    callback: (oldPath: string, newPath: string) => unknown,
+    ctx?: unknown,
+  ): EventRef;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on(name: string, callback: (...data: any) => any, ctx?: any): EventRef;
@@ -14,8 +25,4 @@ export interface Index<T, E extends Error> extends Map<string, Either<E, T>> {
   off(name: string, callback: (...data: any) => any): void;
 
   offref(ref: EventRef): void;
-
-  trigger(name: "changed", path: string): void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trigger(name: string, ...data: any[]): void;
 }

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -1,10 +1,10 @@
 import { Index } from "indexer/index-interface";
 import { rootLogger } from "logger";
+import { Logger } from "loglevel";
 import { type CachedMetadata } from "obsidian";
 import { Either, Left } from "utils/either";
 import { IronVaultKind } from "../constants";
 import { IndexImpl } from "./index-impl";
-import { Logger } from "loglevel";
 
 export type IndexErrorResult<E extends Error> = { type: "error"; error: E };
 export type IndexUpdateResult<V, E extends Error> =
@@ -117,10 +117,11 @@ export abstract class BaseIndexer<T, E extends Error> implements Indexer {
   }
 
   onRename(oldPath: string, newPath: string): void {
-    const previous = this.index.get(oldPath);
-    if (previous) {
-      this.index.delete(oldPath);
-      this.index.set(newPath, previous);
+    if (!this.index.rename(oldPath, newPath)) {
+      this.#logger.warn(
+        "Missing expected key '%s' in rename operation",
+        oldPath,
+      );
     }
   }
 

--- a/src/indexer/manager.ts
+++ b/src/indexer/manager.ts
@@ -62,7 +62,7 @@ export class IndexManager extends Component {
 
     this.registerEvent(
       this.vault.on("rename", (file, oldPath) => {
-        const indexer = this.currentIndexerForFile(file.path);
+        const indexer = this.currentIndexerForFile(oldPath);
         if (indexer != null) {
           this.indexedFiles.delete(oldPath);
           indexer.onRename(oldPath, file.path);

--- a/src/utils/ui/tracked-entity-renderer.ts
+++ b/src/utils/ui/tracked-entity-renderer.ts
@@ -1,0 +1,149 @@
+import IronVaultPlugin from "index";
+import { Index } from "indexer";
+import { html, render } from "lit-html";
+import { rootLogger } from "logger";
+import { debounce, MarkdownRenderChild } from "obsidian";
+import { IronVaultPluginSettings } from "settings";
+
+const logger = rootLogger.getLogger("tracked-entity");
+
+export abstract class TrackedEntityRenderer<
+  T,
+  E extends Error,
+> extends MarkdownRenderChild {
+  #sourcePath: string;
+
+  constructor(
+    containerEl: HTMLElement,
+    sourcePath: string,
+    public readonly plugin: IronVaultPlugin,
+    public readonly index: Index<T, E>,
+    public readonly kind: string,
+  ) {
+    super(containerEl);
+    this.#sourcePath = sourcePath;
+    logger.debug(
+      "[tracked-entity-renderer(%s): %s] Initializing",
+      this.kind,
+      this.sourcePath,
+    );
+  }
+
+  get sourcePath(): string {
+    return this.#sourcePath;
+  }
+
+  async onload() {
+    logger.debug(
+      "[tracked-entity-renderer(%s): %s] onload",
+      this.kind,
+      this.sourcePath,
+    );
+
+    const rerender = debounce(() => this.render(), 100);
+
+    this.registerEvent(
+      this.index.on("changed", (changedPath) => {
+        if (changedPath === this.sourcePath) {
+          logger.debug(
+            "[tracked-entity-renderer(%s): %s] changed",
+            this.kind,
+            this.sourcePath,
+          );
+          rerender();
+        }
+      }),
+    );
+
+    this.registerEvent(
+      this.index.on("renamed", (oldPath, newPath) => {
+        if (this.#sourcePath === oldPath) {
+          logger.debug(
+            "[tracked-entity-renderer(%s): %s] renaming to %s",
+            this.kind,
+            this.sourcePath,
+            newPath,
+          );
+          this.#sourcePath = newPath;
+          // Future optimization: we only need to re-render if the render functions rely on the
+          // source path. In practice, I doubt this matters?
+          rerender();
+        }
+      }),
+    );
+
+    // The character blocks watch for settings changes, and this makes that possible!
+    const watched = this.watchedSettings;
+    if (watched == ALL_SETTINGS) {
+      this.register(this.plugin.settings.on("change", () => rerender()));
+    } else if (watched.size > 0) {
+      this.register(
+        this.plugin.settings.on("change", ({ key }) => {
+          if (watched.has(key)) {
+            rerender();
+          }
+        }),
+      );
+    }
+
+    this.render();
+  }
+
+  render(): void | Promise<void> {
+    logger.debug(
+      "[tracked-entity-renderer(%s): %s] render",
+      this.kind,
+      this.sourcePath,
+    );
+
+    const result = this.index.get(this.sourcePath);
+    if (result == null) {
+      return this.renderMissingEntity();
+    } else if (result.isLeft()) {
+      return this.renderInvalidEntity(result.error);
+    } else {
+      return this.renderEntity(result.value);
+    }
+  }
+
+  /** Called to render an entity that is invalid.
+   * Override this to provide a different error message.
+   */
+  protected renderInvalidEntity(error: E): void | Promise<void> {
+    // TODO(@cwegrzyn): can I get a kind for the index?
+    render(
+      html`<article class="error">
+        Invalid ${this.kind} at '${this.sourcePath}':
+        <pre>
+${error.message}
+        </pre
+        >
+      </article>`,
+      this.containerEl,
+    );
+  }
+
+  protected renderMissingEntity(): void | Promise<void> {
+    render(
+      html`<article class="error">
+        Error: no ${this.kind} indexed at path '${this.sourcePath}'
+      </article>`,
+      this.containerEl,
+    );
+  }
+
+  /** Called to render a valid entity. */
+  abstract renderEntity(entity: T): void | Promise<void>;
+
+  /** Override this to define settings that should trigger a re-render.
+   *
+   * Return either a set of settings to return or the special symbol TrackedEntityRenderer.ALL_SETTINGS to trigger on all settings.
+   * Note that this is currently expected to be contstant.
+   */
+  get watchedSettings():
+    | Set<keyof IronVaultPluginSettings>
+    | typeof ALL_SETTINGS {
+    return new Set();
+  }
+}
+export const ALL_SETTINGS: unique symbol = Symbol("ALL_SETTINGS");


### PR DESCRIPTION
- Fixes a bug where renames were not actually processed ever in the indexer DOH!
- Adds a rename event to the tracked entity indexes, so that renderers can update the path they track
- Introduces an abstract base class for tracked entity renderers that handles the repetitive work (including the new rename handler)

Fixes #286