### PR TITLE
add entities for sundered isles

### DIFF
--- a/data/sundered-isles.supplement.json
+++ b/data/sundered-isles.supplement.json
@@ -1,0 +1,77 @@
+{
+  "type": "expansion",
+  "_id": "sundered_isles_supp",
+  "title": "Sundered Isles Iron Vault Support",
+  "datasworn_version": "0.1.0",
+  "ruleset": "sundered_isles",
+  "oracles": {
+    "templates": {
+      "_id": "oracle_collection:sundered_isles_supp/templates",
+      "name": "Templates",
+      "type": "oracle_collection",
+      "oracle_type": "tables",
+      "_source": {
+        "title": "Iron Vault Support Oracles for Sundered Isles",
+        "authors": [
+          {
+            "name": "Iron Vault Dev Team"
+          }
+        ],
+        "date": "2024-06-15",
+        "url": "https://github.com/iron-vault-plugin/iron-vault",
+        "license": "MIT"
+      },
+      "collections": {},
+      "contents": {
+        "region": {
+          "_id": "oracle_rollable:sundered_isles_supp/core/region",
+          "name": "Region",
+          "dice": "1d100",
+          "type": "oracle_rollable",
+          "oracle_type": "table_text",
+          "_source": {
+            "title": "Iron Vault Support Oracles for Sundered Isles",
+            "authors": [
+              {
+                "name": "Iron Vault Dev Team"
+              }
+            ],
+            "date": "2024-06-15",
+            "url": "https://github.com/iron-vault-plugin/iron-vault",
+            "license": "MIT"
+          },
+          "column_labels": {
+            "roll": "Roll",
+            "text": "Region"
+          },
+          "rows": [
+            {
+              "_id": "oracle_rollable.row:sundered_isles_supp/core/region.0",
+              "roll": {
+                "min": 1,
+                "max": 45
+              },
+              "text": "Myriads"
+            },
+            {
+              "_id": "oracle_rollable.row:sundered_isles_supp/core/region.1",
+              "roll": {
+                "min": 46,
+                "max": 80
+              },
+              "text": "Margins"
+            },
+            {
+              "_id": "oracle_rollable.row:sundered_isles_supp/core/region.2",
+              "roll": {
+                "min": 81,
+                "max": 100
+              },
+              "text": "Reaches"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/data/sundered-isles.supplement.yaml
+++ b/data/sundered-isles.supplement.yaml
@@ -1,0 +1,53 @@
+---
+type: expansion
+_id: sundered_isles_supp
+title: "Sundered Isles Iron Vault Support"
+datasworn_version: 0.1.0
+ruleset: sundered_isles
+oracles:
+  templates:
+    _id: oracle_collection:sundered_isles_supp/templates
+    name: Templates
+    type: oracle_collection
+    oracle_type: tables
+    _source:
+      title: Iron Vault Support Oracles for Sundered Isles
+      authors:
+        - name: Iron Vault Dev Team
+      date: "2024-06-15"
+      url: "https://github.com/iron-vault-plugin/iron-vault"
+      license: "MIT"
+    collections: {}
+    contents:
+      "region":
+        _id: oracle_rollable:sundered_isles_supp/core/region
+        name: Region
+        dice: "1d100"
+        type: oracle_rollable
+        oracle_type: table_text
+        _source:
+          title: Iron Vault Support Oracles for Sundered Isles
+          authors:
+            - name: Iron Vault Dev Team
+          date: "2024-06-15"
+          url: "https://github.com/iron-vault-plugin/iron-vault"
+          license: "MIT"
+        column_labels:
+          roll: Roll
+          text: Region
+        rows:
+          - _id: oracle_rollable.row:sundered_isles_supp/core/region.0
+            roll:
+              min: 1
+              max: 45
+            text: "Myriads"
+          - _id: oracle_rollable.row:sundered_isles_supp/core/region.1
+            roll:
+              min: 46
+              max: 80
+            text: "Margins"
+          - _id: oracle_rollable.row:sundered_isles_supp/core/region.2
+            roll:
+              min: 81
+              max: 100
+            text: "Reaches"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "jest",
     "build": "tsc --noEmit && node esbuild.config.js production",
     "dev:build": "tsc --noEmit && node esbuild.config.js nowatch",
-    "compile-data": "yq -ojson data/starforged.supplement.yaml > data/starforged.supplement.json",
+    "compile-data": "yq -ojson data/starforged.supplement.yaml > data/starforged.supplement.json && yq -ojson data/sundered-isles.supplement.yaml > data/sundered-isles.supplement.json",
     "dev": "node esbuild.config.js",
     "bump": "node ./scripts/update_manifest.js ${npm_config_tag:?} && npm version --no-git-tag-version ${npm_config_tag} && git commit -a -m \"bumping manifest version to ${npm_config_tag}\" && git tag -a ${npm_config_tag} -m ${npm_config_tag} && git push --follow-tags",
     "latestrev": "git tag -l --sort -creatordate '[0-9]*' | head -n 1",

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -323,6 +323,13 @@ export class Datastore extends Component implements IDataContext {
     return new OracleRoller(this.oracles);
   }
 
+  get rulesPackages(): StandardIndex<Datasworn.RulesPackage> {
+    this.assertReady();
+    return this.indexer.prioritized
+      .ofKind("rules_package")
+      .projected((entry) => entry.value);
+  }
+
   get ruleset(): Ruleset {
     this.assertReady();
 

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -29,6 +29,7 @@ import { Component, Notice, TFile, TFolder, type App } from "obsidian";
 import { OracleRoller } from "oracles/roller";
 import { Ruleset } from "rules/ruleset";
 import starforgedSupp from "../data/starforged.supplement.json" assert { type: "json" };
+import sunderedSupp from "../data/sundered-isles.supplement.json" assert { type: "json" };
 import { PLUGIN_DATASWORN_VERSION } from "./constants";
 
 const logger = rootLogger.getLogger("datastore");
@@ -91,6 +92,7 @@ export class Datastore extends Component implements IDataContext {
 
     if (this.plugin.settings.enableSunderedIsles) {
       this.indexBuiltInData(sunderedIslesPackage as Datasworn.Expansion);
+      this.indexBuiltInData(sunderedSupp as Datasworn.Expansion, 5);
     }
 
     if (this.plugin.settings.useHomebrew) {

--- a/src/entity/command.ts
+++ b/src/entity/command.ts
@@ -130,7 +130,11 @@ export async function generateEntityCommand(
           (plugin.settings.enableStarforged &&
             v.collectionId?.startsWith("oracle_collection:starforged/")) ||
           (plugin.settings.enableIronsworn &&
-            v.collectionId?.startsWith("oracle_collection:classic/")),
+            v.collectionId?.startsWith("oracle_collection:classic/")) ||
+          (plugin.settings.enableIronswornDelve &&
+            v.collectionId?.startsWith("oracle_collection:delve/")) ||
+          (plugin.settings.enableSunderedIsles &&
+            v.collectionId?.startsWith("oracle_collection:sundered_isles/")),
       ),
       ([_key, { label }]) => label,
       undefined,

--- a/src/entity/command.ts
+++ b/src/entity/command.ts
@@ -25,6 +25,7 @@ import {
   EntityResults,
   EntitySpec,
 } from "./specs";
+import { extractDataswornLinkParts } from "datastore/parsers/datasworn/id";
 
 type OraclePromptOption =
   | { action: "pick"; row: OracleRollableRow }
@@ -137,7 +138,19 @@ export async function generateEntityCommand(
             v.collectionId?.startsWith("oracle_collection:sundered_isles/")),
       ),
       ([_key, { label }]) => label,
-      undefined,
+      (match, el) => {
+        const collId = match.item[1].collectionId;
+        if (collId) {
+          const path = extractDataswornLinkParts(collId)![1];
+          const [rulesetId] = path.split("/");
+          const ruleset = plugin.datastore.rulesPackages.get(rulesetId);
+          if (ruleset) {
+            el.createEl("small", { cls: "iron-vault-suggest-hint" })
+              .createEl("strong")
+              .createEl("em", { text: ruleset.title });
+          }
+        }
+      },
       "What kind of entity?",
     );
     entityDesc = desc;

--- a/src/entity/specs.ts
+++ b/src/entity/specs.ts
@@ -303,4 +303,100 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
       },
     },
   },
+  siRuin: {
+    label: "Ruin",
+    collectionId: "oracle_collection:sundered_isles/ruin",
+    spec: {
+      location: {
+        id: "oracle_rollable:sundered_isles/ruin/location",
+        firstLook: true,
+        definesAttribute: {
+          order: 1,
+          mechanism: AttributeMechanism.Snakecase,
+        },
+      },
+      condition: {
+        id: "oracle_rollable:sundered_isles/ruin/condition",
+        firstLook: true,
+      },
+      scope: {
+        id: "oracle_rollable:sundered_isles/ruin/scope",
+        firstLook: true,
+      },
+      first_look: {
+        id: "oracle_rollable:sundered_isles/ruin/first_look",
+        firstLook: true,
+      },
+      mystery: {
+        id: "oracle_rollable:sundered_isles/ruin/mystery",
+      },
+      cipher: {
+        id: "oracle_rollable:sundered_isles/ruin/cipher",
+      },
+      feature: {
+        id: "oracle_rollable:sundered_isles/ruin/feature",
+      },
+      peril: {
+        id: "oracle_rollable:sundered_isles/ruin/peril",
+      },
+      opportunity: {
+        id: "oracle_rollable:sundered_isles/ruin/opportunity",
+      },
+    },
+  },
+  siCharacter: {
+    label: "NPC",
+    collectionId: "oracle_collection:sundered_isles/character",
+    nameGen: (ent) =>
+      // NB(@zkat): We use smart quotes here because `"` is an invalid
+      // character in Windows filenames and `'` looks like shit. They look
+      // nice anyway.
+      `${ent.given_name[0]?.simpleResult}${ent.moniker.length > 0 ? " “" + ent.moniker[0].simpleResult + "”" : ""} ${ent.family_name[0]?.simpleResult}`,
+    spec: {
+      given_name: {
+        id: "oracle_rollable:sundered_isles/character/name/given_name",
+        firstLook: true,
+      },
+      moniker: {
+        id: "oracle_rollable:sundered_isles/character/name/moniker",
+        firstLook: true,
+      },
+      family_name: {
+        id: "oracle_rollable:sundered_isles/character/name/family_name",
+        firstLook: true,
+      },
+      first_look: {
+        id: "oracle_rollable:sundered_isles/character/first_look",
+        firstLook: true,
+        name: "First look",
+      },
+      disposition: {
+        id: "oracle_rollable:sundered_isles/character/initial_disposition",
+        firstLook: true,
+      },
+      roles: {
+        id: "oracle_rollable:sundered_isles/character/roles",
+        firstLook: true,
+        definesAttribute: {
+          order: 1,
+          mechanism: AttributeMechanism.ParseId,
+        },
+      },
+      role_details: {
+        id: "oracle_rollable:sundered_isles/character/role_details/{{roles}}",
+      },
+      trademark_accessories: {
+        id: "oracle_rollable:sundered_isles/character/trademark_accessories",
+      },
+      trademark_weapons: {
+        id: "oracle_rollable:sundered_isles/character/trademark_weapons",
+      },
+      details: {
+        id: "oracle_rollable:sundered_isles/character/details",
+      },
+      goals: {
+        id: "oracle_rollable:sundered_isles/character/goals",
+      },
+    },
+  },
 };

--- a/src/entity/specs.ts
+++ b/src/entity/specs.ts
@@ -183,59 +183,6 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
       },
     },
   },
-
-  sfSettlement: {
-    label: "Settlement",
-    nameGen: (ent) => ent.name[0]?.simpleResult,
-    collectionId: "oracle_collection:starforged/settlement",
-    spec: {
-      region: {
-        id: "oracle_rollable:starforgedsupp/core/region",
-        firstLook: true,
-        definesAttribute: {
-          order: 1,
-          mechanism: AttributeMechanism.Snakecase,
-        },
-      },
-      name: {
-        id: "oracle_rollable:starforged/settlement/name",
-        firstLook: true,
-      },
-      location: {
-        id: "oracle_rollable:starforged/settlement/location",
-        firstLook: true,
-      },
-      population: {
-        id: "oracle_rollable:starforged/settlement/population/{{region}}",
-        firstLook: true,
-        name: "Population",
-      },
-      authority: {
-        id: "oracle_rollable:starforged/settlement/authority",
-        firstLook: true,
-      },
-      project: {
-        id: "oracle_rollable:starforged/settlement/projects",
-        firstLook: true,
-      },
-      firstLook: {
-        id: "oracle_rollable:starforged/settlement/first_look",
-        // lol this is ironic, but that's what the rulebook says
-        firstLook: false,
-        name: "First look",
-      },
-      initialContact: {
-        id: "oracle_rollable:starforged/settlement/initial_contact",
-        firstLook: false,
-        name: "Initial contact",
-      },
-      trouble: {
-        id: "oracle_rollable:starforged/settlement/trouble",
-        firstLook: false,
-      },
-    },
-  },
-
   sfPlanet: {
     label: "Planet",
     nameGen: (ent) => ent.name[0]?.simpleResult,
@@ -306,6 +253,53 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
         id: "oracle_rollable:classic/character/goal",
         firstLook: false,
         name: "Character goal",
+      },
+    },
+  },
+  siIsland: {
+    label: "Island",
+    nameGen: (ent) => ent.name[0]?.simpleResult,
+    collectionId: "oracle_collection:sundered_isles/island",
+    spec: {
+      region: {
+        id: "oracle_rollable:sundered_isles_supp/core/region",
+        firstLook: true,
+        definesAttribute: {
+          order: 1,
+          mechanism: AttributeMechanism.Snakecase,
+        },
+      },
+      name: {
+        id: "oracle_rollable:sundered_isles/island/name",
+        firstLook: true,
+      },
+      size: {
+        id: "oracle_rollable:sundered_isles/island/landscape/size",
+        firstLook: true,
+      },
+      terrain: {
+        id: "oracle_rollable:sundered_isles/island/landscape/terrain",
+        firstLook: true,
+      },
+      vitality: {
+        id: "oracle_rollable:sundered_isles/island/landscape/vitality/{{region}}",
+        firstLook: true,
+        name: "Vitality",
+      },
+      nearby_islands: {
+        id: "oracle_rollable:sundered_isles/island/nearby_islands/{{region}}",
+        firstLook: true,
+        name: "Nearby islands",
+      },
+      coastline_aspects: {
+        id: "oracle_rollable:sundered_isles/island/coastline_aspects",
+      },
+      offshore_observations: {
+        id: "oracle_rollable:sundered_isles/island/offshore_observations",
+      },
+      visible_habitation: {
+        id: "oracle_rollable:sundered_isles/island/visible_habitation/{{region}}",
+        name: "Visible habitation",
       },
     },
   },

--- a/src/sidebar/oracles.ts
+++ b/src/sidebar/oracles.ts
@@ -82,7 +82,7 @@ function getOracleTree(
       rulesets.set(ruleset.id, ruleset);
     }
 
-    let grouping = groupings.get(groupName);
+    let grouping = groupings.get(oracle.parent.id);
     if (!grouping) {
       grouping = {
         id: oracle.parent.id,
@@ -90,7 +90,7 @@ function getOracleTree(
         children: [],
       };
       ruleset.children.push(grouping);
-      groupings.set(groupName, grouping);
+      groupings.set(oracle.parent.id, grouping);
     }
 
     grouping.children.push(oracle);


### PR DESCRIPTION
Fixes: https://github.com/iron-vault-plugin/iron-vault/issues/373

* [x] Display origin ruleset in `Create an entity` command picker
* [x] Island entity
* [x] NPC
* [x] Ruin

Cursed oracles won't be supported yet. That's coming with #349 