### PR TITLE
Fix bug when selecting suggested folder

### DIFF
--- a/src/clocks/clock-create-modal.ts
+++ b/src/clocks/clock-create-modal.ts
@@ -69,7 +69,11 @@ export class ClockCreateModal extends Modal {
     const folderSetting = new Setting(contentEl)
       .setName("Target folder")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         folderComponent = search
           .setPlaceholder("Choose a folder")
           .setValue(this.result.targetFolder)

--- a/src/entity/modal.ts
+++ b/src/entity/modal.ts
@@ -331,8 +331,8 @@ export class EntityModal<T extends EntitySpec> extends Modal {
         search
           .setPlaceholder("Choose a folder")
           .setValue(this.results.targetFolder)
-          .onChange(() => {
-            const normalized = normalizePath(search.getValue());
+          .onChange((newFolder) => {
+            const normalized = normalizePath(newFolder);
             this.results.targetFolder = normalized;
             if (this.app.vault.getFolderByPath(normalized)) {
               targetFolderSetting.setDesc(

--- a/src/entity/modal.ts
+++ b/src/entity/modal.ts
@@ -323,12 +323,16 @@ export class EntityModal<T extends EntitySpec> extends Modal {
     const targetFolderSetting = new Setting(contentEl)
       .setName("Target folder")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         search
           .setPlaceholder("Choose a folder")
           .setValue(this.results.targetFolder)
-          .onChange((newFolder) => {
-            const normalized = normalizePath(newFolder);
+          .onChange(() => {
+            const normalized = normalizePath(search.getValue());
             this.results.targetFolder = normalized;
             if (this.app.vault.getFolderByPath(normalized)) {
               targetFolderSetting.setDesc(

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -126,7 +126,11 @@ export class IronVaultSettingTab extends PluginSettingTab {
       .setName("Homebrew content folder")
       .setDesc("Load custom rulesets from this folder.")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         search
           .setPlaceholder("Type the name of a folder")
           .setValue(settings.homebrewPath)
@@ -252,7 +256,11 @@ export class IronVaultSettingTab extends PluginSettingTab {
       .setName("Default progress track folder")
       .setDesc("Create progress tracks in this folder by default.")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         search
           .setPlaceholder("Type the name of a folder")
           .setValue(settings.defaultProgressTrackFolder)
@@ -279,7 +287,11 @@ export class IronVaultSettingTab extends PluginSettingTab {
       .setName("Default clock folder")
       .setDesc("Create clocks in this folder by default.")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         search
           .setPlaceholder("Type the name of a folder")
           .setValue(settings.defaultClockFolder)
@@ -302,7 +314,11 @@ export class IronVaultSettingTab extends PluginSettingTab {
       .setName("Default characters folder")
       .setDesc("Create player characters in this folder by default.")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
+
         search
           .setPlaceholder("Type the name of a folder")
           .setValue(settings.defaultCharactersFolder)

--- a/src/tracks/progress-create.ts
+++ b/src/tracks/progress-create.ts
@@ -75,7 +75,10 @@ export class ProgressTrackCreateModal extends Modal {
     const folderSetting = new Setting(contentEl)
       .setName("Target folder")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
         folderComponent = search
           .setPlaceholder("Choose a folder")
           .setValue(this.result.targetFolder)

--- a/src/truths/command.ts
+++ b/src/truths/command.ts
@@ -69,7 +69,10 @@ class GenerateTruthsModal extends Modal {
     const folderSetting = new Setting(contentEl)
       .setName("Target folder")
       .addSearch((search) => {
-        new FolderTextSuggest(this.app, search.inputEl);
+        new FolderTextSuggest(this.app, search.inputEl, (val: string) => {
+          search.setValue(val);
+          search.onChanged();
+        });
         folderComponent = search
           .setPlaceholder("Choose a folder")
           .setValue(this.result.targetFolder)

--- a/src/utils/ui/settings/folder.ts
+++ b/src/utils/ui/settings/folder.ts
@@ -1,6 +1,13 @@
-import { AbstractInputSuggest, TFolder } from "obsidian";
+import { AbstractInputSuggest, App, TFolder } from "obsidian";
 
 export class FolderTextSuggest extends AbstractInputSuggest<TFolder> {
+  constructor(
+    app: App,
+    textInputEl: HTMLInputElement | HTMLDivElement,
+    private onSelectCallBack: (value: string) => void = () => {},
+  ) {
+    super(app, textInputEl);
+  }
   getSuggestions(inputStr: string): TFolder[] {
     const searchStr = inputStr.toLowerCase();
 
@@ -19,6 +26,7 @@ export class FolderTextSuggest extends AbstractInputSuggest<TFolder> {
 
   selectSuggestion(item: TFolder): void {
     this.setValue(item.path);
+    this.onSelectCallBack(item.path);
     this.close();
   }
 }


### PR DESCRIPTION
This fixes an issue where if you select the helper auto fill text on the folder selection input it doesn't register that it was selected so entities, progress tracks etc... don't actually get created where a user would expect them to. 