### PR TITLE
Fixes for Saving Homebrew Folder

### DIFF
--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -192,6 +192,7 @@ export class Datastore extends Component implements IDataContext {
             walkDataswornRulesPackage(source, dataswornPackage, this.plugin),
           );
         } catch (e) {
+          new Notice(`Unable to import homebrew file: ${file.basename}`, 0);
           logger.error(e);
           continue;
         }

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -131,10 +131,28 @@ export class IronVaultSettingTab extends PluginSettingTab {
           search.onChanged();
         });
 
+        let isValidPath = true;
+
+        search.inputEl.addEventListener("blur", () => {
+          if (!isValidPath) {
+            search.inputEl.addClass("iv-invalid-setting");
+          } else {
+            search.inputEl.removeClass("iv-invalid-setting");
+          }
+        });
+
         search
           .setPlaceholder("Type the name of a folder")
           .setValue(settings.homebrewPath)
-          .onChange((value) => this.updateSetting("homebrewPath", value));
+          .onChange((value) => {
+            const homebrewFolder = this.plugin.app.vault.getFolderByPath(value);
+            if (homebrewFolder === null) {
+              isValidPath = false;
+              return;
+            }
+            isValidPath = true;
+            this.updateSetting("homebrewPath", value);
+          });
       });
 
     new Setting(containerEl).setName("Dice").setHeading();

--- a/src/styles.css
+++ b/src/styles.css
@@ -80,3 +80,7 @@
   it so you can't select text in modals. */
   user-select: text;
 }
+
+.iv-invalid-setting {
+  border-color: var(--color-red, red) !important;
+}


### PR DESCRIPTION
This is a fix for #292  and #293 . For the first it just pops a notice saying the file is un-parsable. For the second it will not save an invalid path (fixing the notifications for each typed letter in the box), but does try to tell the user it is invalid by highighting the field red onBlur(). Honestly, obsidian could give us a little more in the way of tooling for validation on their settings object, but this is a good-faith attempt to let a user know something is wrong. 