### PR TITLE
Added Support for Multiple Rolls in Enitity Generation

### DIFF
--- a/src/datastore/parsers/datasworn/oracles.ts
+++ b/src/datastore/parsers/datasworn/oracles.ts
@@ -10,7 +10,13 @@ import {
   OracleRow,
   RollContext,
 } from "../../../model/oracle";
-import { Roll, RollResultKind, Subroll, sameRoll } from "../../../model/rolls";
+import {
+  NumberRange,
+  Roll,
+  RollResultKind,
+  Subroll,
+  sameRoll,
+} from "../../../model/rolls";
 import { Dice, DieKind } from "../../../utils/dice";
 import { DiceGroup } from "utils/dice-group";
 
@@ -65,6 +71,10 @@ export class DataswornOracle implements Oracle {
 
   get id(): string {
     return this.table._id;
+  }
+
+  get recommended_rolls(): NumberRange | undefined {
+    return this.table.recommended_rolls;
   }
 
   get dice(): Dice {

--- a/src/model/oracle.ts
+++ b/src/model/oracle.ts
@@ -43,6 +43,7 @@ export interface Oracle {
   readonly raw: Datasworn.OracleRollable | Datasworn.EmbeddedOracleRollable;
   readonly cursedBy?: Oracle;
   readonly curseBehavior?: CurseBehavior;
+  readonly recommended_rolls?: NumberRange;
 
   row(value: number): OracleRow;
 


### PR DESCRIPTION
This adds support for re-roller oracles entries for entities when it is specified in Datasworn. In short, when more than 1 roll is recommended, it shows how many rolls are suggested and then when you click the dice icon it switches to a 'circle-arrow' icon and when clicked again it appends the next roll instead of clearing it out. 

It doesn't actually limit a person on how many re-rolls they want to do. It could, but didn't seem worth the effort, so I am just letting the player decide that. 

If accepted this should close #161 