### PR TITLE
Split up the graphic dice settings for oracle and action action dice

### DIFF
--- a/src/datastore/parsers/datasworn/oracles.ts
+++ b/src/datastore/parsers/datasworn/oracles.ts
@@ -114,10 +114,13 @@ export class DataswornOracle implements Oracle {
         ],
         this.plugin,
       );
-      const res = await group.roll();
+      const res = await group.roll(this.plugin.settings.graphicalOracleDice);
       return this.evaluate(context, res[0].value, res[1].value, cursed.id);
     }
-    return this.evaluate(context, await this.dice.roll());
+    return this.evaluate(
+      context,
+      await this.dice.roll(this.plugin?.settings.graphicalOracleDice ?? true),
+    );
   }
 
   async evaluate(

--- a/src/moves/action/action-modal.ts
+++ b/src/moves/action/action-modal.ts
@@ -155,7 +155,7 @@ export async function rerollDie(
           : dieName === "vs1"
             ? DieKind.Challenge1
             : DieKind.Challenge2,
-      ).roll());
+      ).roll(plugin.settings.graphicalActionDice));
   }
   const props: { action?: string; vs1?: string; vs2?: string } = {};
   props[dieName] = newValue;

--- a/src/moves/action/index.ts
+++ b/src/moves/action/index.ts
@@ -246,7 +246,7 @@ async function processActionMove(
         new Dice(1, 10, plugin, DieKind.Challenge2),
       ],
       plugin,
-    ).roll();
+    ).roll(plugin.settings.graphicalActionDice);
     roll = {
       action: res[0].value,
       challenge1: res[1].value,
@@ -282,7 +282,7 @@ async function processProgressMove(
         new Dice(1, 10, plugin, DieKind.Challenge2),
       ],
       plugin,
-    ).roll();
+    ).roll(plugin.settings.graphicalActionDice);
     roll = {
       challenge1: res[0].value,
       challenge2: res[1].value,

--- a/src/oracles/modal.ts
+++ b/src/oracles/modal.ts
@@ -54,7 +54,7 @@ export class OracleRollerModal extends Modal {
               this.plugin.settings.cursedDieSides,
               this.plugin,
               DieKind.Cursed,
-            ).roll();
+            ).roll(this.plugin.settings.graphicalOracleDice);
             await setRoll(this.currentRoll.withCursedRoll(newCursedRoll));
             await onUpdateCursedRoll();
           }),

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,7 +1,8 @@
 import Emittery from "emittery";
 
 export class IronVaultPluginSettings {
-  graphicalDice: boolean = true;
+  graphicalOracleDice: boolean = true;
+  graphicalActionDice: boolean = true;
   actionDieColor: string = "#8f8f8f";
   challengeDie1Color: string = "#8b5cf5";
   challengeDie2Color: string = "#8b5cf5";

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -242,12 +242,29 @@ export class IronVaultSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Graphical dice")
-      .setDesc("If enabled, dice rolls will use on-screen 3d graphical dice.")
+      .setName("Graphical oracle dice")
+      .setDesc(
+        "If enabled, dice rolls will use on-screen 3d graphical dice when making oracle rolls.",
+      )
       .addToggle((toggle) => {
         toggle
-          .setValue(settings.graphicalDice)
-          .onChange((value) => this.updateSetting("graphicalDice", value));
+          .setValue(settings.graphicalOracleDice)
+          .onChange((value) =>
+            this.updateSetting("graphicalOracleDice", value),
+          );
+      });
+
+    new Setting(containerEl)
+      .setName("Graphical action dice")
+      .setDesc(
+        "If enabled, dice rolls will use on-screen 3d graphical dice when making action and progress rolls.",
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(settings.graphicalActionDice)
+          .onChange((value) =>
+            this.updateSetting("graphicalActionDice", value),
+          );
       });
 
     new Setting(containerEl)

--- a/src/truths/truth-block.ts
+++ b/src/truths/truth-block.ts
@@ -295,7 +295,7 @@ async function pickRandomSubOption(
   plugin: IronVaultPlugin,
 ) {
   const dice = Dice.fromDiceString(table.dice, plugin, DieKind.Oracle);
-  const res = await dice.roll();
+  const res = await dice.roll(plugin.settings.graphicalOracleDice);
   return table.rows.findIndex(
     (row) => row.roll!.min <= res && res <= row.roll!.max,
   );
@@ -306,7 +306,7 @@ async function pickRandomOption(truth: Truth, plugin: IronVaultPlugin) {
   if (options.every((option) => option.roll != null)) {
     // Do a dice roll
     const die = Dice.fromDiceString(truth.dice, plugin, DieKind.Oracle);
-    const res = await die.roll();
+    const res = await die.roll(plugin.settings.graphicalOracleDice);
     return options.find((opt) => opt.roll.min <= res && res <= opt.roll.max);
   } else {
     return options[Math.floor(Math.random() * options.length)];

--- a/src/utils/dice-group.ts
+++ b/src/utils/dice-group.ts
@@ -1,5 +1,5 @@
 import IronVaultPlugin from "index";
-import { Dice } from "./dice";
+import { Dice, randomInt } from "./dice";
 import { RollResult } from "@3d-dice/dice-box";
 
 export class DiceGroup {
@@ -8,7 +8,12 @@ export class DiceGroup {
     private plugin: IronVaultPlugin,
   ) {}
 
-  async roll(): Promise<RollResult[]> {
+  async roll(displayDice: boolean): Promise<RollResult[]> {
+    if (!displayDice) {
+      return this.dice.map((d) => {
+        return { value: randomInt(d.minRoll(), d.maxRoll()) } as RollResult;
+      });
+    }
     return await this.plugin.diceOverlay.roll(
       this.dice.map((d) => ({
         qty: d.count,

--- a/src/utils/dice-overlay.ts
+++ b/src/utils/dice-overlay.ts
@@ -54,10 +54,7 @@ export class DiceOverlay {
     container?.classList.toggle("active", true);
     const roll = await this.diceBox.roll(dice);
     const listener = (ev: KeyboardEvent | MouseEvent) => {
-      if (
-        (ev instanceof KeyboardEvent && ev.key === "Escape") ||
-        ev instanceof MouseEvent
-      ) {
+      if (ev instanceof KeyboardEvent || ev instanceof MouseEvent) {
         container?.classList.toggle("active", false);
         this.diceBox.clear();
         container?.removeEventListener("click", listener);

--- a/src/utils/dice.test.ts
+++ b/src/utils/dice.test.ts
@@ -4,7 +4,7 @@ it("parses and rolls", async () => {
   const dice = Dice.fromDiceString("3d4");
   expect(dice.count).toBe(3);
   expect(dice.sides).toBe(4);
-  expect(await dice.roll()).toBeGreaterThanOrEqual(3);
+  expect(await dice.roll(false)).toBeGreaterThanOrEqual(3);
   expect(dice.maxRoll()).toBe(12);
 });
 

--- a/src/utils/dice.ts
+++ b/src/utils/dice.ts
@@ -46,9 +46,9 @@ export class Dice {
     public readonly kind?: DieKind,
   ) {}
 
-  async roll(): Promise<number> {
-    if (this.plugin?.settings.graphicalDice) {
-      const res = await this.plugin.diceOverlay.roll({
+  async roll(displayDice: boolean): Promise<number> {
+    if (displayDice) {
+      const res = await this.plugin!.diceOverlay.roll({
         qty: this.count,
         sides: this.sides,
         themeColor: this.themeColor,

--- a/src/utils/dice.ts
+++ b/src/utils/dice.ts
@@ -47,8 +47,8 @@ export class Dice {
   ) {}
 
   async roll(displayDice: boolean): Promise<number> {
-    if (displayDice) {
-      const res = await this.plugin!.diceOverlay.roll({
+    if (displayDice && this.plugin) {
+      const res = await this.plugin.diceOverlay.roll({
         qty: this.count,
         sides: this.sides,
         themeColor: this.themeColor,


### PR DESCRIPTION
This does what the title says, and also makes it so you can clear out the dice on any keypress in addition to mouse clicking.
This should close #408  and #359 