### PR TITLE
Index scope data

### DIFF
--- a/src/campaigns/context.ts
+++ b/src/campaigns/context.ts
@@ -1,4 +1,3 @@
-import { Asset, RulesPackage } from "@datasworn/core/dist/Datasworn";
 import { CharacterContext } from "character-tracker";
 import { ClockFileAdapter } from "clocks/clock-file";
 import { BaseDataContext, ICompleteDataContext } from "datastore/data-context";
@@ -6,13 +5,9 @@ import {
   DataIndexer,
   SourcedByArray,
   SourcedKindsArray,
-  StandardIndex,
 } from "datastore/data-indexer";
-import {
-  DataswornIndexer,
-  DataswornTypes,
-  MoveWithSelector,
-} from "datastore/datasworn-indexer";
+import { DataswornIndexer, DataswornTypes } from "datastore/datasworn-indexer";
+import { scopeTags } from "datastore/datasworn-symbols";
 import IronVaultPlugin from "index";
 import { ReadonlyIndex } from "indexer/index-interface";
 import { OracleRoller } from "oracles/roller";
@@ -64,20 +59,16 @@ export class CampaignDataContext
   clocks: ReadonlyIndex<ClockFileAdapter, ZodError>;
   progressTracks: ReadonlyIndex<ProgressTrackFileAdapter, ZodError>;
 
-  get moves(): StandardIndex<MoveWithSelector> {
+  get moves() {
     return this.dataContext.moves;
   }
 
-  get assets(): StandardIndex<Asset> {
+  get assets() {
     return this.dataContext.assets;
   }
 
   get moveCategories() {
     return this.dataContext.moveCategories;
-  }
-
-  get moveRulesets() {
-    return this.dataContext.moveRulesets;
   }
 
   get oracles() {
@@ -88,7 +79,7 @@ export class CampaignDataContext
     return this.dataContext.truths;
   }
 
-  get rulesPackages(): StandardIndex<RulesPackage> {
+  get rulesPackages() {
     return this.dataContext.rulesPackages;
   }
 
@@ -99,6 +90,7 @@ export class CampaignDataContext
   get prioritized() {
     return this.dataContext.prioritized;
   }
+
   diceRollerFor(kind: "move"): AsyncDiceRoller & DiceRoller {
     switch (kind) {
       case "move":
@@ -124,8 +116,9 @@ export class PlaysetAwareDataContext extends BaseDataContext {
             (sourced) =>
               // TODO(@cwegrzyn): maybe I should be more open ended with the type on determine's obj?
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              playsetConfig.determine(sourced.id, sourced.value as any) ===
-              Determination.Include,
+              playsetConfig.determine(sourced.id, {
+                tags: sourced.value[scopeTags],
+              }) === Determination.Include,
           );
           return filtered.length > 0
             ? (filtered as SourcedByArray<DataswornTypes>)

--- a/src/campaigns/ui/playset-editor.ts
+++ b/src/campaigns/ui/playset-editor.ts
@@ -31,7 +31,6 @@ function createSearchIndex(
   });
 
   for (const [_id, item] of baseData.prioritized.entries() ?? []) {
-    if (item.kind == "move_ruleset") continue;
     index.add({
       _id,
       kind: item.kind,

--- a/src/characters/action-context.ts
+++ b/src/characters/action-context.ts
@@ -1,9 +1,9 @@
-import { RulesPackage } from "@datasworn/core/dist/Datasworn";
 import { CampaignDataContext } from "campaigns/context";
 import { determineCampaignContext } from "campaigns/manager";
 import { IDataContext } from "datastore/data-context";
 import { StandardIndex } from "datastore/data-indexer";
-import { DataswornTypes, moveOrigin } from "datastore/datasworn-indexer";
+import { DataswornTypes } from "datastore/datasworn-indexer";
+import { moveOrigin } from "datastore/datasworn-symbols";
 import { produce } from "immer";
 import { App, MarkdownFileInfo } from "obsidian";
 import { OracleRoller } from "oracles/roller";
@@ -57,7 +57,7 @@ export class NoCharacterActionConext implements IActionContext {
     return this.campaignContext.oracleRoller;
   }
 
-  get rulesPackages(): StandardIndex<RulesPackage> {
+  get rulesPackages() {
     return this.campaignContext.rulesPackages;
   }
 
@@ -75,10 +75,6 @@ export class NoCharacterActionConext implements IActionContext {
 
   get moveCategories() {
     return this.campaignContext.moveCategories;
-  }
-
-  get moveRulesets() {
-    return this.campaignContext.moveRulesets;
   }
 
   get oracles() {
@@ -132,7 +128,7 @@ export class CharacterActionContext implements IActionContext {
     return this.campaignContext.oracleRoller;
   }
 
-  get rulesPackages(): StandardIndex<RulesPackage> {
+  get rulesPackages() {
     return this.campaignContext.rulesPackages;
   }
 
@@ -169,10 +165,6 @@ export class CharacterActionContext implements IActionContext {
 
   get moveCategories() {
     return this.campaignContext.moveCategories;
-  }
-
-  get moveRulesets() {
-    return this.campaignContext.moveRulesets;
   }
 
   get oracles() {

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -140,7 +140,7 @@ export class Datastore extends Component {
       path: mainPath,
       priority,
     });
-    this.indexer.index(source, walkDataswornRulesPackage(source, pkg));
+    this.indexer.index(source, walkDataswornRulesPackage(pkg));
 
     this.app.metadataCache.trigger("iron-vault:index-changed");
   }
@@ -187,7 +187,7 @@ export class Datastore extends Component {
           });
           this.indexer.index(
             source,
-            walkDataswornRulesPackage(source, dataswornPackage),
+            walkDataswornRulesPackage(dataswornPackage),
           );
         } catch (e) {
           new Notice(`Unable to import homebrew file: ${file.basename}`, 0);

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -177,10 +177,6 @@ export class Datastore extends Component {
             continue;
           }
           const dataswornPackage = data as Datasworn.RulesPackage;
-          // const rulesetId =
-          //   dataswornPackage.type == "ruleset"
-          //     ? dataswornPackage._id
-          //     : dataswornPackage.ruleset;
           const source = createSource({
             path: file.path,
             priority: 10,

--- a/src/datastore.ts
+++ b/src/datastore.ts
@@ -6,7 +6,7 @@ import starforgedRuleset from "@datasworn/starforged/json/starforged.json" asser
 import sunderedIslesPackage from "@datasworn/sundered-isles/json/sundered_isles.json" assert { type: "json" };
 import Ajv from "ajv";
 import { BaseDataContext } from "datastore/data-context";
-import { DataIndexer, SourceTag } from "datastore/data-indexer";
+import { DataIndexer } from "datastore/data-indexer";
 import {
   DataswornIndexer,
   createSource,
@@ -139,7 +139,6 @@ export class Datastore extends Component {
     const source = createSource({
       path: mainPath,
       priority,
-      sourceTags: { [SourceTag.RulesetId]: pkg._id },
     });
     this.indexer.index(source, walkDataswornRulesPackage(source, pkg));
 
@@ -178,14 +177,13 @@ export class Datastore extends Component {
             continue;
           }
           const dataswornPackage = data as Datasworn.RulesPackage;
-          const rulesetId =
-            dataswornPackage.type == "ruleset"
-              ? dataswornPackage._id
-              : dataswornPackage.ruleset;
+          // const rulesetId =
+          //   dataswornPackage.type == "ruleset"
+          //     ? dataswornPackage._id
+          //     : dataswornPackage.ruleset;
           const source = createSource({
             path: file.path,
             priority: 10,
-            sourceTags: { [SourceTag.RulesetId]: rulesetId },
           });
           this.indexer.index(
             source,

--- a/src/datastore/data-context.ts
+++ b/src/datastore/data-context.ts
@@ -1,21 +1,16 @@
 import { Datasworn } from "@datasworn/core";
-import { Asset, Rules } from "@datasworn/core/dist/Datasworn";
+import { Rules } from "@datasworn/core/dist/Datasworn";
 import merge from "lodash.merge";
 import { Ruleset } from "rules/ruleset";
 import { VersionedMapImpl } from "utils/versioned-map";
 import { SourcedMap, SourcedMapImpl, StandardIndex } from "./data-indexer";
-import {
-  DataswornIndex,
-  DataswornTypes,
-  moveOrigin,
-  MoveWithSelector,
-} from "./datasworn-indexer";
+import { DataswornIndex, DataswornTypes } from "./datasworn-indexer";
+import { moveOrigin, scopeSource, scopeTags } from "./datasworn-symbols";
 
 export interface IDataContext {
   readonly moves: StandardIndex<DataswornTypes["move"]>;
   readonly assets: StandardIndex<DataswornTypes["asset"]>;
   readonly moveCategories: StandardIndex<DataswornTypes["move_category"]>;
-  readonly moveRulesets: StandardIndex<DataswornTypes["move_ruleset"]>;
   readonly oracles: StandardIndex<DataswornTypes["oracle"]>;
   readonly truths: StandardIndex<DataswornTypes["truth"]>;
 
@@ -31,7 +26,6 @@ export class MockDataContext implements IDataContext {
   readonly moves: StandardIndex<DataswornTypes["move"]>;
   readonly assets: StandardIndex<DataswornTypes["asset"]>;
   readonly moveCategories: StandardIndex<DataswornTypes["move_category"]>;
-  readonly moveRulesets: StandardIndex<DataswornTypes["move_ruleset"]>;
   readonly oracles: StandardIndex<DataswornTypes["oracle"]>;
   readonly truths: StandardIndex<DataswornTypes["truth"]>;
 
@@ -39,17 +33,31 @@ export class MockDataContext implements IDataContext {
     moves,
     assets,
   }: {
-    moves?: Datasworn.AnyMove[];
+    moves?: Datasworn.Move[];
     assets?: Datasworn.Asset[];
   }) {
     this.moves = new VersionedMapImpl(
-      (moves ?? []).map((move) => [move._id, { ...move, [moveOrigin]: {} }]),
+      (moves ?? []).map((move) => [
+        move._id,
+        {
+          ...move,
+          [moveOrigin]: {},
+          [scopeSource]: move._source,
+          [scopeTags]: move.tags ?? {},
+        },
+      ]),
     );
     this.assets = new VersionedMapImpl(
-      (assets ?? []).map((asset) => [asset._id, asset]),
+      (assets ?? []).map((asset) => [
+        asset._id,
+        {
+          ...asset,
+          [scopeSource]: asset._source,
+          [scopeTags]: asset.tags ?? {},
+        },
+      ]),
     );
     this.moveCategories = new VersionedMapImpl();
-    this.moveRulesets = new VersionedMapImpl();
     this.oracles = new VersionedMapImpl();
     this.truths = new VersionedMapImpl();
   }
@@ -73,35 +81,29 @@ export class BaseDataContext implements ICompleteDataContext {
     );
   }
 
-  get moves(): StandardIndex<MoveWithSelector> {
+  get moves() {
     return this.prioritized.ofKind("move").projected((entry) => entry.value);
   }
 
-  get assets(): StandardIndex<Asset> {
+  get assets() {
     return this.prioritized.ofKind("asset").projected((entry) => entry.value);
   }
 
-  get moveCategories(): StandardIndex<DataswornTypes["move_category"]> {
+  get moveCategories() {
     return this.prioritized
       .ofKind("move_category")
       .projected((entry) => entry.value);
   }
 
-  get moveRulesets(): StandardIndex<DataswornTypes["move_ruleset"]> {
-    return this.prioritized
-      .ofKind("move_ruleset")
-      .projected((entry) => entry.value);
-  }
-
-  get oracles(): StandardIndex<DataswornTypes["oracle"]> {
+  get oracles() {
     return this.prioritized.ofKind("oracle").projected((entry) => entry.value);
   }
 
-  get truths(): StandardIndex<DataswornTypes["truth"]> {
+  get truths() {
     return this.prioritized.ofKind("truth").projected((entry) => entry.value);
   }
 
-  get rulesPackages(): StandardIndex<DataswornTypes["rules_package"]> {
+  get rulesPackages() {
     return this.prioritized
       .ofKind("rules_package")
       .projected((entry) => entry.value);
@@ -110,7 +112,7 @@ export class BaseDataContext implements ICompleteDataContext {
   // TODO: this should return an error if the datacontext houses
   //       too many rulesets.
   // handles base vs expansion
-  get ruleset(): Ruleset {
+  get ruleset() {
     const ids: string[] = [];
     const rules = [...this.prioritized.ofKind("rules_package").values()]
       .map((pkg) => {

--- a/src/datastore/data-indexer.ts
+++ b/src/datastore/data-indexer.ts
@@ -8,16 +8,10 @@ import {
 
 const logger = rootLogger.getLogger("data-indexer");
 
-export enum SourceTag {
-  RulesetId = "ruleset-id",
-  ExpansionId = "expansion-id",
-}
-
 export type Source = {
   path: string;
   priority: number;
   keys: Set<string>;
-  sourceTags: Partial<Record<SourceTag, symbol>>;
 };
 
 export type SourcedKinds<Kinds> = {

--- a/src/datastore/datasworn-indexer.test.ts
+++ b/src/datastore/datasworn-indexer.test.ts
@@ -15,7 +15,6 @@ describe("Datasworn Indexer", () => {
     const source: Source = createSource({
       path: "@datasworn/starforged",
       priority: 0,
-      sourceTags: { "ruleset-id": Symbol.for(starforgedPackage._id) },
     });
     const indexer: DataswornIndexer = new DataIndexer();
     indexer.index(

--- a/src/datastore/datasworn-indexer.test.ts
+++ b/src/datastore/datasworn-indexer.test.ts
@@ -20,7 +20,6 @@ describe("Datasworn Indexer", () => {
     indexer.index(
       source,
       walkDataswornRulesPackage(
-        source,
         // @ts-expect-error tsc compiler seems to infer starforged JSON types weirdly
         starforgedPackage as Datasworn.RulesPackage,
       ),

--- a/src/datastore/datasworn-indexer.test.ts
+++ b/src/datastore/datasworn-indexer.test.ts
@@ -6,9 +6,9 @@ import {
   createSource,
   DataswornIndexer,
   DataswornTypes,
-  moveOrigin,
   walkDataswornRulesPackage,
 } from "./datasworn-indexer";
+import { moveOrigin, scopeSource, scopeTags } from "./datasworn-symbols";
 
 describe("Datasworn Indexer", () => {
   const createIndex = () => {
@@ -57,6 +57,7 @@ describe("Datasworn Indexer", () => {
   });
 
   it("should index asset-linked-moves", () => {
+    const empath = starforgedPackage.assets.path.contents.empath;
     const [readHeart] = indexer.dataMap.get(
       "asset.ability.move:starforged/path/empath.0.read_heart",
     )!;
@@ -64,9 +65,12 @@ describe("Datasworn Indexer", () => {
       id: "asset.ability.move:starforged/path/empath.0.read_heart",
       kind: "move",
       source: { path: "@datasworn/starforged" },
-      value:
-        starforgedPackage.assets.path.contents.empath.abilities[0].moves
-          ?.read_heart,
+      value: {
+        ...empath.abilities[0].moves!.read_heart,
+        // These should pull from the parent asset
+        [scopeSource]: empath._source,
+        [scopeTags]: empath.tags,
+      },
     });
 
     assertIsKind<DataswornTypes, "move">(readHeart, "move");
@@ -104,6 +108,19 @@ describe("Datasworn Indexer", () => {
         id: "starforged",
         name: "Ironsworn: Starforged Rulebook",
       },
+      [scopeSource]: {
+        authors: [
+          {
+            name: "Shawn Tomkin",
+          },
+        ],
+        date: "2022-05-06",
+        license: "https://creativecommons.org/licenses/by/4.0",
+        page: 229,
+        title: "Ironsworn: Starforged Rulebook",
+        url: "https://ironswornrpg.com",
+      },
+      [scopeTags]: {},
     });
   });
 

--- a/src/datastore/datasworn-indexer.ts
+++ b/src/datastore/datasworn-indexer.ts
@@ -10,7 +10,6 @@ import {
   DataIndex,
   DataIndexer,
   Source,
-  SourceTag,
   Sourced,
   SourcedBy,
 } from "./data-indexer";
@@ -42,18 +41,11 @@ export type DataswornIndexer = DataIndexer<DataswornTypes>;
 export function createSource(fields: {
   path: string;
   priority?: number;
-  sourceTags: Partial<Record<SourceTag, string | symbol>>;
 }): Source {
   return {
     path: fields.path,
     priority: fields.priority ?? 0,
     keys: new Set(),
-    sourceTags: Object.fromEntries(
-      Object.entries(fields.sourceTags).map(([key, val]) => [
-        key,
-        typeof val == "symbol" ? val : Symbol.for(val),
-      ]),
-    ),
   };
 }
 

--- a/src/datastore/datasworn-indexer.ts
+++ b/src/datastore/datasworn-indexer.ts
@@ -9,8 +9,9 @@ import {
 import {
   DataIndex,
   DataIndexer,
+  PreSourced,
+  PreSourcedBy,
   Source,
-  Sourced,
   SourcedBy,
 } from "./data-indexer";
 import { DataswornOracle } from "./parsers/datasworn/oracles";
@@ -50,13 +51,12 @@ export function createSource(fields: {
 }
 
 export function* walkDataswornRulesPackage(
-  source: Source,
   input: Datasworn.RulesPackage,
-): Iterable<DataswornSourced> {
+): Iterable<PreSourcedBy<DataswornTypes>> {
   function make<T extends { _id: string; type: string }>(
     obj: T,
-  ): Sourced<T["type"], T> {
-    return { source, id: obj._id, kind: obj.type, value: obj };
+  ): PreSourced<T["type"], T> {
+    return { id: obj._id, kind: obj.type, value: obj };
   }
 
   const rootGrouping: OracleRulesetGrouping = {
@@ -74,7 +74,6 @@ export function* walkDataswornRulesPackage(
         id: "ruleset_for_" + move._id,
         kind: "move_ruleset",
         value: input,
-        source,
       };
 
       const moveOracleGroup: OracleCollectionGrouping = {
@@ -89,7 +88,6 @@ export function* walkDataswornRulesPackage(
           id: oracle._id,
           kind: "oracle",
           value: new DataswornOracle(oracle, moveOracleGroup),
-          source,
         };
       }
     }
@@ -106,7 +104,6 @@ export function* walkDataswornRulesPackage(
             id: "ruleset_for_" + move._id,
             kind: "move_ruleset",
             value: input,
-            source,
           };
         }
       }
@@ -114,14 +111,14 @@ export function* walkDataswornRulesPackage(
   }
 
   for (const oracle of walkOracles(input)) {
-    yield { id: oracle.id, kind: "oracle", value: oracle, source };
+    yield { id: oracle.id, kind: "oracle", value: oracle };
   }
 
   for (const truth of Object.values(input.truths ?? {})) {
-    yield { id: truth._id, kind: "truth", value: truth, source };
+    yield { id: truth._id, kind: "truth", value: truth };
   }
 
-  yield { id: input._id, kind: "rules_package", value: input, source };
+  yield { id: input._id, kind: "rules_package", value: input };
 }
 
 function* walkOracles(data: Datasworn.RulesPackage): Generator<Oracle> {

--- a/src/datastore/datasworn-symbols.ts
+++ b/src/datastore/datasworn-symbols.ts
@@ -1,0 +1,3 @@
+export const moveOrigin: unique symbol = Symbol("iv:moveOrigin");
+export const scopeTags: unique symbol = Symbol("iv:scopeTags");
+export const scopeSource: unique symbol = Symbol("iv:scopeSource");

--- a/src/datastore/parsers/datasworn/oracles.ts
+++ b/src/datastore/parsers/datasworn/oracles.ts
@@ -1,11 +1,12 @@
 import { type Datasworn } from "@datasworn/core";
+import { scopeSource, scopeTags } from "datastore/datasworn-symbols";
 import { rootLogger } from "logger";
 import { DiceGroup } from "utils/dice-group";
 import { NoSuchOracleError } from "../../../model/errors";
 import {
   CurseBehavior,
   Oracle,
-  OracleGrouping,
+  OracleCollectionGrouping,
   OracleRollableRow,
   OracleRow,
   RollContext,
@@ -38,8 +39,19 @@ export class DataswornOracle implements Oracle {
     protected readonly table:
       | Datasworn.OracleRollable
       | Datasworn.EmbeddedOracleRollable,
-    public readonly parent: OracleGrouping,
+    public readonly parent: OracleCollectionGrouping,
+    private readonly _scopeTags: Datasworn.Tags,
   ) {}
+
+  get [scopeTags](): Datasworn.Tags {
+    return this._scopeTags;
+  }
+
+  get [scopeSource](): Datasworn.SourceInfo {
+    return "_source" in this.table
+      ? this.table._source
+      : this.parent[scopeSource];
+  }
 
   get raw(): Datasworn.OracleRollable | Datasworn.EmbeddedOracleRollable {
     return this.table;

--- a/src/model/oracle.ts
+++ b/src/model/oracle.ts
@@ -1,4 +1,5 @@
 import { type Datasworn } from "@datasworn/core";
+import { scopeSource, scopeTags } from "datastore/datasworn-symbols";
 import { Dice } from "utils/dice";
 import { AsyncDiceRoller, DiceRoller } from "utils/dice-roller";
 import { NumberRange, Roll } from "./rolls";
@@ -24,6 +25,8 @@ export interface OracleCollectionGrouping {
   readonly id: string;
   readonly parent: OracleGrouping;
   readonly name: string;
+  readonly [scopeSource]: Datasworn.SourceInfo;
+  readonly [scopeTags]: Datasworn.Tags;
 }
 
 export interface OracleRulesetGrouping {
@@ -42,9 +45,12 @@ export type OracleGrouping = OracleRulesetGrouping | OracleCollectionGrouping;
 export interface Oracle {
   readonly id: string;
   readonly name: string;
-  readonly parent: OracleGrouping;
+  readonly parent: OracleCollectionGrouping;
   readonly rollableRows: OracleRollableRow[];
   readonly dice: Dice;
+
+  readonly [scopeSource]: Datasworn.SourceInfo;
+  readonly [scopeTags]: Datasworn.Tags;
 
   // TODO(@cwegrzyn): exposed raw rollable for use in the oracle reference modal. not sure
   //   to what extent it is useful to abstract some of this stuff away...

--- a/src/moves/move-modal.ts
+++ b/src/moves/move-modal.ts
@@ -1,6 +1,10 @@
 import { determineCharacterActionContext } from "characters/action-context";
 import { IDataContext } from "datastore/data-context";
-import { AnyDataswornMove } from "datastore/datasworn-indexer";
+import {
+  AnyDataswornMove,
+  DataswornTypes,
+  scopeSourceForMove,
+} from "datastore/datasworn-indexer";
 import IronVaultPlugin from "index";
 import { html, render } from "lit-html";
 import { map } from "lit-html/directives/map.js";
@@ -36,7 +40,7 @@ export class MoveModal extends Modal {
     return view && view instanceof MarkdownView ? view : undefined;
   }
 
-  async openMove(move: AnyDataswornMove) {
+  async openMove(move: DataswornTypes["move"]) {
     this.setTitle(move.name);
     const { contentEl } = this;
     contentEl.empty();
@@ -44,7 +48,7 @@ export class MoveModal extends Modal {
     contentEl.toggleClass("iron-vault-modal", true);
     contentEl.toggleClass("iron-vault-move-modal", true);
     contentEl.createEl("header", {
-      text: this.dataContext.moveRulesets.get("ruleset_for_" + move._id)?.title,
+      text: scopeSourceForMove(move).title,
     });
     const view = this.getActiveMarkdownView();
     // NOTE(@cwegrzyn): I've taken the approach here that if there is no active view, let's

--- a/src/oracles/command.ts
+++ b/src/oracles/command.ts
@@ -10,30 +10,22 @@ import {
   type MarkdownView,
 } from "obsidian";
 import { numberRange } from "utils/numbers";
-import { CurseBehavior, Oracle, OracleGroupingType } from "../model/oracle";
+import {
+  CurseBehavior,
+  Oracle,
+  OracleGrouping,
+  OracleGroupingType,
+} from "../model/oracle";
 import { Roll, RollWrapper } from "../model/rolls";
 import { CustomSuggestModal } from "../utils/suggest";
 import { OracleRollerModal } from "./modal";
+import { oracleNameWithParents } from "./render";
 import { OracleRoller } from "./roller";
 
 const logger = rootLogger.getLogger("oracles");
 
-export function formatOraclePath(oracle: Oracle): string {
-  let current = oracle.parent;
-  const path = [];
-  while (
-    current != null &&
-    current.grouping_type != OracleGroupingType.Ruleset
-  ) {
-    path.unshift(current.name);
-    current = current.parent;
-  }
-  path.push(oracle.name);
-  return `${path.join(" / ")}`;
-}
-
 export function oracleRuleset(oracle: Oracle): string {
-  let current = oracle.parent;
+  let current: OracleGrouping = oracle.parent;
   while (
     current != null &&
     current.grouping_type !== OracleGroupingType.Ruleset
@@ -96,7 +88,7 @@ export async function runOracleCommand(
     oracle = await CustomSuggestModal.select(
       plugin.app,
       oracles,
-      formatOraclePath,
+      oracleNameWithParents,
       (match, el) => {
         const ruleset = oracleRuleset(match.item);
         el.createEl("small", { cls: "iron-vault-suggest-hint" })

--- a/src/oracles/oracle-modal.ts
+++ b/src/oracles/oracle-modal.ts
@@ -1,5 +1,5 @@
 import IronVaultPlugin from "index";
-import { Oracle, OracleGroupingType } from "model/oracle";
+import { Oracle, OracleGrouping, OracleGroupingType } from "model/oracle";
 import { App, ButtonComponent, MarkdownView, Modal } from "obsidian";
 import { runOracleCommand } from "oracles/command";
 import { generateOracleTable } from "./render";
@@ -19,7 +19,7 @@ export class OracleModal extends Modal {
     contentEl.toggleClass("iron-vault-modal-content", true);
     contentEl.classList.toggle("iron-vault-oracle-modal", true);
     contentEl.toggleClass("iron-vault-modal", true);
-    let ruleset = oracle.parent;
+    let ruleset: OracleGrouping = oracle.parent;
     while (
       oracle.parent &&
       ruleset.grouping_type !== OracleGroupingType.Ruleset

--- a/src/oracles/render.ts
+++ b/src/oracles/render.ts
@@ -1,10 +1,10 @@
 import { Datasworn } from "@datasworn/core";
 import { App, MarkdownRenderChild, MarkdownRenderer } from "obsidian";
-import { Oracle, OracleGroupingType } from "../model/oracle";
+import { Oracle, OracleGrouping, OracleGroupingType } from "../model/oracle";
 
 export function oracleNameWithParents(oracle: Oracle): string {
   const steps = [oracle.name];
-  let next = oracle.parent;
+  let next: OracleGrouping = oracle.parent;
   while (next && next.grouping_type != OracleGroupingType.Ruleset) {
     steps.unshift(next.name);
     next = next.parent;

--- a/src/sidebar/moves.ts
+++ b/src/sidebar/moves.ts
@@ -4,6 +4,7 @@ import { map } from "lit-html/directives/map.js";
 import MiniSearch from "minisearch";
 
 import { IDataContext } from "datastore/data-context";
+import { AnyDataswornMove } from "datastore/datasworn-indexer";
 import IronVaultPlugin from "index";
 import { MoveModal } from "moves/move-modal";
 import { md } from "utils/ui/directives";
@@ -98,7 +99,12 @@ function renderCategory(
       <ol class="content">
         ${map(
           Object.values(category.contents ?? {}),
-          (move) => html`${renderMove(plugin, dataContext, move)}`,
+          (move) =>
+            html`${renderMove(
+              plugin,
+              dataContext,
+              dataContext.moves.get(move._id)!,
+            )}`,
         )}
       </ol>
     </div>
@@ -108,7 +114,7 @@ function renderCategory(
 function renderMove(
   plugin: IronVaultPlugin,
   dataContext: IDataContext,
-  move: Move,
+  move: AnyDataswornMove,
 ) {
   return html`
     <li


### PR DESCRIPTION
The original problem here was ensuring that a playset would include an embedded entity when it included the parent entity, in the case that the parent entity was included/excluded based on tags. As a concrete example, `asset:starforged/path/empath` and `asset.ability.move:starforged/path/empath.0.read_heart`. The sundered isles w/ supernatural moves playset should include both, because of the supernatural tag on empath. The ID regex mechanics include both, but the original tag mechanics did not, because the embedded move doesn't have the tag, only the parent asset.

This solves that problem by enriching indexed items with "scopeTags", which merge in all tags from parent entities.

I also needed to solve a similar problem with the move_ruleset index. I did that by tracking the "scope source" which is the value of the nearest _source field to the entity.