### PR TITLE
Add hot-reload plugin as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,15 @@ docs/.obsidian/plugins/iron-vault
 docs/.obsidian/workspace.json
 # Tells obsidian what plugins are enabled
 !test-vault/.obsidian/community-plugins.json
-# This plugin should still be tracked by git.
-# It might need updated at some point
-!test-vault/.obsidian/hot-reload-master/*
+# Include hot-reload plugin to be tracked by git.
+# Note that negating an exclusion only works for a direct subdirectory,
+# not deeper nested directories, i.e. plugins/ but not plugins/hot-reload/
+# To include plugins/hot-reload/, we first need to include plugins/ itself,
+# instantly exclude everything from it again, and then explicitly include
+# its hot-reload/ subdirectory.
+!test-vault/.obsidian/plugins
+test-vault/.obsidian/plugins/*
+!test-vault/.obsidian/plugins/hot-reload
 
 # Don't track this folder. For random things to try.
 # If it's important to test, add it somewhere where other

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-vault/.obsidian/plugins/hot-reload"]
+	path = test-vault/.obsidian/plugins/hot-reload
+	url = https://github.com/pjeby/hot-reload.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,17 @@ in the [Ironsworn Discord](https://discord.gg/xTxmR9UZTC)
 
 ## Development
 
-To get set up with the project, clone the repo first, then `pnpm i` (you have
+To get set up with the project, clone the repo first (use `--recurse-submodules`
+if you want the hot-reload plugin added, see below), then `pnpm i` (you have
 to install `pnpm` specifically, yes). You can then build the production
 version of the plugin with `pnpm build`.
 
 To play around, you can run `pnpm dev`, which watches for code changes,
 compiles, and then deploys into the test vault. You can open up the test-vault
 in obsidian and, with the hot-reload plugin enabled, new updates will be
-loaded automatically.
+loaded automatically. The [hot-reload plugin](https://github.com/pjeby/hot-reload)
+is added as a git submodule, so either use `git clone --recurse-submodules` or
+run `git submodule update --init` if you already cloned the repo.
 
 There is a `test-vault` included in the repo that can be used as a sandbox
 during development.


### PR DESCRIPTION
The hot-reload plugin directory exists in `test-vault/.obsidian/plugins/` and is somewhat indicated as a submodule in GitHub, but there's no actual submodule set up for it, presumably prevented by exclusion rules in `.gitignore`.

This PR
 - adjusts `.gitignore` to explicitly negate exclusion for `test-vault/.obsidian/plugins/hot-reload`
 - adds hot-reload as submodule
 - mentions it in the `CONTRIBUTING.md` development set up instructions