### PR TITLE
Only render oracles as links in oracle roller modal

### DIFF
--- a/src/oracles/new-modal.ts
+++ b/src/oracles/new-modal.ts
@@ -227,13 +227,21 @@ export class NewOracleRollerModal extends Modal {
                         );
                       } else {
                         const subOracle = rolled.context.lookup(id);
-                        return html`<a
-                          aria-label=${subOracle?.name}
-                          data-tooltip-position="top"
-                          @click=${(ev: MouseEvent) =>
-                            this._subrollClick(ev, i, id, 0)}
-                          >${label}</a
-                        >`;
+                        if (subOracle) {
+                          return html`<a
+                            aria-label=${subOracle?.name}
+                            data-tooltip-position="top"
+                            @click=${(ev: MouseEvent) =>
+                              this._subrollClick(ev, i, id, 0)}
+                            >${label}</a
+                          >`;
+                        } else {
+                          return html`<span
+                            aria-label=${id}
+                            data-tooltip-position="top"
+                            >${label}</span
+                          >`;
+                        }
                       }
                     });
                   };


### PR DESCRIPTION
I seem to have forgotten to check that the link is actually an oracle link. Planetary class (as an example) includes links to a whole oracle_collection, which confused the click function for the roller.

Fixes #494