### PR TITLE
Fix editing embedded progress/clock blocks

### DIFF
--- a/src/clocks/clock-block.ts
+++ b/src/clocks/clock-block.ts
@@ -44,6 +44,9 @@ class ClockRenderer extends TrackedEntityRenderer<ClockFileAdapter, ZodError> {
             ? html`<input
                 type="text"
                 .value=${clockFile.name}
+                @click=${(ev: Event) => {
+                  ev.stopPropagation(); // See notes in track-block.ts
+                }}
                 @blur=${async () => {
                   this.editingName = false;
                   setTimeout(() => this.render(), 0);
@@ -62,7 +65,8 @@ class ClockRenderer extends TrackedEntityRenderer<ClockFileAdapter, ZodError> {
                 }}
               />`
             : html`<span
-                @click=${() => {
+                @click=${(ev: Event) => {
+                  ev.stopPropagation(); // See notes in track-block.ts
                   this.editingName = true;
                   this.render();
                   const el = this.containerEl.querySelector(
@@ -83,7 +87,8 @@ class ClockRenderer extends TrackedEntityRenderer<ClockFileAdapter, ZodError> {
         <div
           class="clock-segments"
           @click=${(ev: Event) => {
-            const target = ev.target as HTMLElement | undefined;
+            const target = ev.currentTarget as HTMLElement | null;
+            ev.stopPropagation();
             if (target?.querySelector("span")) {
               this.editingSegments = true;
               this.render();
@@ -95,6 +100,9 @@ class ClockRenderer extends TrackedEntityRenderer<ClockFileAdapter, ZodError> {
             ? html`<input
                 type="number"
                 .value=${clockFile.clock.segments}
+                @click=${(ev: Event) => {
+                  ev.stopPropagation(); // See notes in track-block.ts
+                }}
                 @blur=${() => {
                   this.editingSegments = false;
                   setTimeout(() => this.render(), 0);
@@ -121,6 +129,9 @@ class ClockRenderer extends TrackedEntityRenderer<ClockFileAdapter, ZodError> {
             <input
               type="checkbox"
               ?checked=${!clockFile.clock.active}
+              @click=${(ev: Event) => {
+                ev.stopPropagation(); // See notes in track-block.ts
+              }}
               @change=${async (ev: Event) =>
                 ev.target &&
                 (await clockUpdater(

--- a/src/tracks/track-block.ts
+++ b/src/tracks/track-block.ts
@@ -114,6 +114,9 @@ export function renderTrack(
           ? html`<textarea
               type="text"
               .value=${info.name}
+              @click=${(ev: Event) => {
+                ev.stopPropagation(); // Prevents the click event from bubbling
+              }}
               @blur=${() => {
                 trackRenderer.editingName = false;
                 setTimeout(() => trackRenderer?.render(), 0);
@@ -125,10 +128,11 @@ export function renderTrack(
               }}
             />`
           : html`<span
-              @click=${() => {
+              @click=${(ev: Event) => {
                 if (!trackRenderer) {
                   return;
                 }
+                ev.stopPropagation();
                 trackRenderer.editingName = true;
                 trackRenderer.render();
                 const el = trackRenderer.containerEl.querySelector(
@@ -147,6 +151,12 @@ export function renderTrack(
                 ${trackRenderer
                   ? html`<select
                       .value=${info.track.rank}
+                      @click=${(ev: Event) => {
+                        // When track is embedded, bubbling the click event causes
+                        // Obsidian to change the selection, which ends up removing
+                        // focus from the select element. This prevents that.
+                        ev.stopPropagation();
+                      }}
                       @change=${(ev: Event) =>
                         updateTrack({
                           rank: (ev.target! as HTMLSelectElement)
@@ -170,6 +180,9 @@ export function renderTrack(
                   ? html`<input
                       type="text"
                       .value=${info.trackType}
+                      @click=${(ev: Event) => {
+                        ev.stopPropagation(); // See above
+                      }}
                       @change=${(ev: Event) =>
                         updateTrack({
                           trackType: (ev.target! as HTMLSelectElement).value,
@@ -184,17 +197,32 @@ export function renderTrack(
         ? html`<span class="track-xp">${xpEarned}</span>`
         : null}
       <div class="track-widget">
-        <button type="button" @click=${() => updateTrack({ steps: -1 })}>
+        <button
+          type="button"
+          @click=${(ev: Event) => {
+            ev.stopPropagation();
+            updateTrack({ steps: -1 });
+          }}
+        >
           -
         </button>
         <ol>
           ${items}
         </ol>
-        <button type="button" @click=${() => updateTrack({ steps: 1 })}>
+        <button
+          type="button"
+          @click=${(ev: Event) => {
+            ev.stopPropagation();
+            updateTrack({ steps: 1 });
+          }}
+        >
           +
         </button>
         <input
           .value="${info.track.progress}"
+          @click=${(ev: Event) => {
+            ev.stopPropagation(); // See above
+          }}
           @change=${(ev: Event) =>
             updateTrack({ ticks: +(ev.target! as HTMLInputElement).value })}
         />


### PR DESCRIPTION
As noted in #521, attempting to make any edits to attributes of tracks and clocks when the blocks were part of a page embeddeding in another would fail. For example, clicking on the track difficulty would pop up the dropdown, but immediately it would close. Turns out what was happening is that the click event was bubbling up to the embed itself, which handled it by changing focus by selecting the embed's markdown text. This PR prevents that by liberally sprinkling `stopPropagation` in click handlers in controls in track/clock blocks.