### PR TITLE
Embed move text in sidebar

### DIFF
--- a/docs/Other Features/Settings.md
+++ b/docs/Other Features/Settings.md
@@ -36,5 +36,7 @@ These options control various parts of how [[Mechanics Blocks]] are rendered.
 * **Hide mechanics completely**: If enabled, mechanics blocks will not be displayed at all. Good for when you just want to read a story. You can also toggle this setting by using the [[Toggle displaying mechanics]] command.
 * **Inline tracks on clock creation**: If enabled, new tracks and clocks will be automatically inlined in the journal when created.
 
+### Legacy
 
+* **Disable embedding moves in sidebar**: This reverts to the pre-1.95.0 move sidebar, which includes only the name and trigger text for the move, and move links-- which open the move modal. Enable this setting if you wish to revert to that old behavior.
 

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -50,7 +50,7 @@ const context = await esbuild.context({
   conditions: prod ? [] : ["development"],
   plugins: [
     inlineWorkerPlugin({
-      sourcemap: prod ? false : "inline", // inline workers with sourcemaps in dev mode}),
+      // sourcemap: prod ? false : "inline", // inline workers with sourcemaps in dev mode}),
       treeShaking: true,
       target: "es2023",
       conditions: ["worker", ...(prod ? [] : ["development"])],

--- a/src/character-tracker.ts
+++ b/src/character-tracker.ts
@@ -100,12 +100,7 @@ export function currentActiveCharacterForCampaign(
 
   return (
     charContext &&
-    new CharacterActionContext(
-      plugin.datastore,
-      campaignContext,
-      charContext[0],
-      charContext[1],
-    )
+    new CharacterActionContext(campaignContext, charContext[0], charContext[1])
   );
 }
 
@@ -145,12 +140,7 @@ export async function promptForCampaignCharacter(
     undefined,
     "Pick active character",
   );
-  return new CharacterActionContext(
-    plugin.datastore,
-    campaignContext,
-    path,
-    charCtx,
-  );
+  return new CharacterActionContext(campaignContext, path, charCtx);
 }
 
 /** Updates the active character for a campaign. */

--- a/src/characters/action-context.ts
+++ b/src/characters/action-context.ts
@@ -24,7 +24,6 @@ import {
   movesReader,
   rollablesReader,
 } from "../characters/lens";
-import { type Datastore } from "../datastore";
 import IronVaultPlugin from "../index";
 import { InfoModal } from "../utils/ui/info";
 import { InvalidCharacterError } from "./errors";
@@ -49,10 +48,7 @@ export class NoCharacterActionConext implements IActionContext {
   readonly kind = "no_character";
   readonly momentum: undefined = undefined;
 
-  constructor(
-    public readonly datastore: Datastore,
-    public readonly campaignContext: CampaignDataContext,
-  ) {}
+  constructor(public readonly campaignContext: CampaignDataContext) {}
 
   get oracleRoller(): OracleRoller {
     return this.campaignContext.oracleRoller;
@@ -123,7 +119,6 @@ export class CharacterActionContext implements IActionContext {
   #moves?: StandardIndex<DataswornTypes["move"]>;
 
   constructor(
-    public readonly datastore: Datastore,
     public readonly campaignContext: CampaignDataContext,
     public readonly characterPath: string,
     public readonly characterContext: CharacterContext,
@@ -282,7 +277,7 @@ export async function determineCharacterActionContext(
       throw new NoValidContextError("No valid character found", { cause: e });
     }
   } else {
-    return new NoCharacterActionConext(plugin.datastore, campaignContext);
+    return new NoCharacterActionConext(campaignContext);
   }
 }
 

--- a/src/characters/character-block.ts
+++ b/src/characters/character-block.ts
@@ -568,7 +568,6 @@ class CharacterRenderer extends TrackedEntityRenderer<
               // TODO(@cwegrzyn): should we be getting the character action context some other way here?
               //   getting the campaign context here is also hacky
               new CharacterActionContext(
-                this.plugin.datastore,
                 this.plugin.campaignManager.campaignContextFor(
                   this.plugin.campaignManager.campaignForPath(this.sourcePath)!,
                 ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,8 +240,8 @@ export default class IronVaultPlugin extends Plugin implements TrackedEntities {
 
   onUserDisable(): void {
     // Detach the sidebar views when the plugin is disabled
-    this.app.workspace.detachLeavesOfType(SIDEBAR_VIEW_TYPE);
-    this.app.workspace.detachLeavesOfType(CONTENT_VIEW_TYPE);
+    // this.app.workspace.detachLeavesOfType(SIDEBAR_VIEW_TYPE);
+    // this.app.workspace.detachLeavesOfType(CONTENT_VIEW_TYPE);
   }
 
   async activateMainSidebarView() {

--- a/src/link-handler.ts
+++ b/src/link-handler.ts
@@ -112,6 +112,28 @@ export default function installLinkHandler(plugin: IronVaultPlugin) {
     // TODO(@cwegrzyn): if we could get the view from the click event, that might be better. Is
     //   that just the active view? That feels gross, but it does seem to make sense...
     const file = plugin.app.vault.getFileByPath(ctx.sourcePath);
+    const component = new MarkdownRenderChild(el);
+    ctx.addChild(component);
+    component.registerDomEvent(el, "click", (ev) => {
+      if (!(ev.target instanceof HTMLAnchorElement)) return;
+      // If the link is not a datasworn link, we don't handle it.
+      if (!ev.target.dataset.dataswornId) return;
+      const campaign = file && plugin.campaignManager.campaignForFile(file);
+      const dataContext =
+        campaign == null
+          ? plugin.datastore.dataContext
+          : plugin.campaignManager.campaignContextFor(campaign);
+      const href =
+        (ev.target as HTMLAnchorElement).attributes.getNamedItem("href")
+          ?.textContent ?? undefined;
+      const entry = findEntry(dataContext, href);
+      if (entry) {
+        ev.stopPropagation();
+        ev.preventDefault();
+        present(dataContext, entry);
+      }
+    });
+
     el.querySelectorAll("a").forEach((a) => {
       // If the link is a potential datasworn link, let's register a handler just in case.
       const href = a.attributes.getNamedItem("href")?.textContent ?? "";
@@ -119,25 +141,6 @@ export default function installLinkHandler(plugin: IronVaultPlugin) {
       if (parsedLink) {
         a.dataset.dataswornId = parsedLink.id;
         a.dataset.dataswornKind = parsedLink.kind;
-
-        const component = new MarkdownRenderChild(a);
-        ctx.addChild(component);
-        component.registerDomEvent(a, "click", (ev) => {
-          const campaign = file && plugin.campaignManager.campaignForFile(file);
-          const dataContext =
-            campaign == null
-              ? plugin.datastore.dataContext
-              : plugin.campaignManager.campaignContextFor(campaign);
-          const href =
-            (ev.target as HTMLAnchorElement).attributes.getNamedItem("href")
-              ?.textContent ?? undefined;
-          const entry = findEntry(dataContext, href);
-          if (entry) {
-            ev.stopPropagation();
-            ev.preventDefault();
-            present(dataContext, entry);
-          }
-        });
       } else {
         delete a.dataset.dataswornId;
         delete a.dataset.dataswornKind;

--- a/src/link-handler.ts
+++ b/src/link-handler.ts
@@ -6,6 +6,7 @@ import { extractDataswornLinkParts } from "datastore/parsers/datasworn/id";
 import { rootLogger } from "logger";
 import { MoveModal } from "moves/move-modal";
 import { MarkdownRenderChild, Notice } from "obsidian";
+import { SidebarView } from "sidebar/sidebar-view";
 import IronVaultPlugin from "./index";
 import { OracleModal } from "./oracles/oracle-modal";
 
@@ -45,7 +46,11 @@ export default function installLinkHandler(plugin: IronVaultPlugin) {
   const present = (dataContext: IDataContext, entry: DataswornSourced) => {
     switch (entry.kind) {
       case "move":
-        new MoveModal(plugin.app, plugin, dataContext, entry.value).open();
+        if (plugin.settings.useLegacyMoveModal) {
+          new MoveModal(plugin.app, plugin, dataContext, entry.value).open();
+        } else {
+          SidebarView.activate(plugin.app, entry.id);
+        }
         break;
       case "asset":
         new AssetModal(plugin.app, plugin, dataContext, entry.value).open();

--- a/src/moves/action/index.ts
+++ b/src/moves/action/index.ts
@@ -466,7 +466,11 @@ export function suggestedRollablesForMove(
           rollableToAdd = rollable.condition_meter;
           break;
         default:
-          logger.warn("unhandled rollable scenario %o %o", condition, rollable);
+          logger.debug(
+            "unhandled rollable scenario %o %o",
+            condition,
+            rollable,
+          );
       }
       if (!rollableToAdd) continue;
       if (!(rollableToAdd in suggestedRollables)) {

--- a/src/moves/css/move-modal.css
+++ b/src/moves/css/move-modal.css
@@ -10,6 +10,11 @@
     color: var(--text-muted);
     font-weight: var(--font-semibold);
   }
+}
+
+.iron-vault-move-buttons {
+  padding-top: 0.5em;
+
   & .rollable-stats {
     display: flex;
     flex-flow: row wrap;

--- a/src/moves/move-modal.ts
+++ b/src/moves/move-modal.ts
@@ -1,14 +1,20 @@
-import { determineCharacterActionContext } from "characters/action-context";
+import {
+  determineCharacterActionContext,
+  IActionContext,
+} from "characters/action-context";
+import { MeterWithLens, MeterWithoutLens } from "characters/lens";
 import { IDataContext } from "datastore/data-context";
 import {
   AnyDataswornMove,
   DataswornTypes,
   scopeSourceForMove,
+  WithMetadata,
 } from "datastore/datasworn-indexer";
 import IronVaultPlugin from "index";
 import { html, render } from "lit-html";
 import { map } from "lit-html/directives/map.js";
 import { ref } from "lit-html/directives/ref.js";
+import { Oracle } from "model/oracle";
 import {
   App,
   ButtonComponent,
@@ -54,84 +60,48 @@ export class MoveModal extends Modal {
     contentEl.createEl("header", {
       text: scopeSourceForMove(move).title,
     });
+
     const view = this.getActiveMarkdownView();
     // NOTE(@cwegrzyn): I've taken the approach here that if there is no active view, let's
     // not prompt the user for a campaign/character just to view a move.
     const context =
       view && (await determineCharacterActionContext(this.plugin, view));
-    const suggested =
-      move.roll_type === "action_roll" && suggestedRollablesForMove(move);
-    if (suggested && context) {
-      const rollsList = contentEl.createEl("ul", { cls: "rollable-stats" });
-      contentEl.appendChild(rollsList);
-      const rollables = context.rollables.filter((r) => suggested[r.key]);
-      render(
-        html`${map(
-          rollables,
-          (meter) => html`
-            <li
-              @click=${() => {
-                const view = this.getActiveMarkdownView();
-                if (view) {
-                  runMoveCommand(this.plugin, view.editor, view, move, meter);
-                  this.close();
-                }
-              }}
-            >
-              <dl>
-                <dt data-value=${meter.definition.label}>
-                  ${meter.definition.label}
-                </dt>
-                <dd data-value=${meter.value}>
-                  <span
-                    ${ref((el) => el && setIcon(el as HTMLElement, "dice"))}
-                  ></span>
-                  <span>+</span>
-                  <span>${meter.value}</span>
-                </dd>
-              </dl>
-            </li>
-          `,
-        )}`,
-        rollsList,
-      );
-    }
-    new ButtonComponent(contentEl)
-      .setButtonText("Make this move with prompts")
-      .onClick(() => {
-        const view = this.getActiveMarkdownView();
-        if (view) {
-          runMoveCommand(this.plugin, view.editor, view, move);
-          this.close();
-        }
-      });
-    const { moveText, oracles } = await this.getMoveText(move);
-    await MarkdownRenderer.render(
-      this.app,
-      moveText,
+
+    await MoveRenderer.render(
       contentEl.createEl("div", { cls: "md-wrapper" }),
-      ".",
+      this.plugin,
+      this.dataContext,
+      move,
       this.modalComponent,
-    );
-    for (const { oracleText, oracle } of oracles) {
-      new ButtonComponent(contentEl)
-        .setButtonText(`Roll ${oracle.name}`)
-        .setTooltip(`Roll on the ${oracle.name} oracle.`)
-        .onClick(() => {
+      {
+        actionContext: context,
+        onMakeMove: (move, meter) => {
+          const view = this.getActiveMarkdownView();
+          if (view) {
+            runMoveCommand(this.plugin, view.editor, view, move, meter);
+          }
+          this.close();
+        },
+        onRollOracle: (oracle) => {
           const view = this.getActiveMarkdownView();
           if (view) {
             runOracleCommand(this.plugin, view.editor, view, oracle);
-            this.close();
           }
-        });
-      await MarkdownRenderer.render(
-        this.app,
-        oracleText,
-        contentEl.createEl("div", { cls: "md-wrapper" }),
-        ".",
-        this.modalComponent,
-      );
-    }
+          this.close();
+        },
+        showOracles: true,
+        onClickDataswornLink: (id, ev) => {
+          ev.preventDefault();
+          ev.stopImmediatePropagation();
+          const newMove = this.dataContext.moves.get(id);
+          if (newMove) {
+            this.moveHistory.push(move);
+            this.openMove(newMove);
+          }
+        },
+      },
+    );
+
     if (this.moveHistory.length) {
       new ButtonComponent(contentEl)
         .setButtonText("Back")
@@ -139,19 +109,6 @@ export class MoveModal extends Modal {
         .onClick(() => {
           this.openMove(this.moveHistory.pop()!);
         });
-    }
-    for (const child of contentEl.querySelectorAll('a[href^="id:"]')) {
-      child.addEventListener("click", (ev) => {
-        const id = child.getAttribute("href")?.slice(3);
-        if (!id) return;
-        ev.preventDefault();
-        ev.stopPropagation();
-        const newMove = this.dataContext.moves.get(id);
-        if (newMove) {
-          this.moveHistory.push(move);
-          this.openMove(newMove);
-        }
-      });
     }
   }
 
@@ -165,60 +122,148 @@ export class MoveModal extends Modal {
     contentEl.empty();
     this.modalComponent.unload();
   }
-
-  async getMoveText(move: AnyDataswornMove) {
-    let moveText = move.text;
-    const oracles = [];
-    for (const match of move.text.matchAll(TABLE_REGEX)) {
-      const oracle = this.dataContext.oracles.get(match[1]);
-      if (oracle) {
-        const dom = await generateOracleTable(
-          this.app,
-          oracle,
-          this.modalComponent,
-        );
-        const oracleText = dom.outerHTML + "\n";
-        oracles.push({ oracleText, oracle });
-        moveText = moveText.replaceAll(match[0], "");
-      }
-    }
-    return { moveText, oracles };
-  }
 }
 
+export type MoveRendererOptions = {
+  actionContext?: IActionContext;
+  onMakeMove?: (
+    move: AnyDataswornMove,
+    meter?: MeterWithLens | MeterWithoutLens,
+  ) => void | Promise<void>;
+  showOracles?: boolean;
+  onRollOracle?: (oracle: WithMetadata<Oracle>) => void | Promise<void>;
+  onClickDataswornLink?: (id: string, ev: MouseEvent) => void | Promise<void>;
+};
+
+/** A Component that represents a rendering of a move definition. */
 export class MoveRenderer extends MarkdownRenderChild {
+  /** Render a move into the given container element. */
   static async render(
+    container: HTMLElement,
     plugin: IronVaultPlugin,
     dataContext: IDataContext,
     move: AnyDataswornMove,
     component: Component,
+    options: MoveRendererOptions = {},
   ): Promise<MoveRenderer> {
-    const container = document.createElement("div");
-    const renderer = new MoveRenderer(container, plugin, dataContext, move);
+    const renderer = new MoveRenderer(
+      container,
+      plugin,
+      dataContext,
+      move,
+      options,
+    );
     component.addChild(renderer);
     await renderer.render();
     return renderer;
   }
 
-  constructor(
+  private constructor(
     readonly containerEl: HTMLElement,
     readonly plugin: IronVaultPlugin,
     readonly dataContext: IDataContext,
     readonly move: AnyDataswornMove,
+    readonly options: MoveRendererOptions,
   ) {
     super(containerEl);
   }
 
+  onunload(): void {
+    this.containerEl.empty();
+    super.onunload();
+  }
+
   async render(): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { containerEl } = this;
+
+    if (this.options.onMakeMove) {
+      const moveButtonsEl = containerEl.createDiv("iron-vault-move-buttons");
+
+      const context = this.options.actionContext;
+      const suggested =
+        this.move.roll_type === "action_roll" &&
+        suggestedRollablesForMove(this.move);
+      if (suggested && context) {
+        const rollsList = moveButtonsEl.createEl("ul", {
+          cls: "rollable-stats",
+        });
+
+        const rollables = context.rollables.filter((r) => suggested[r.key]);
+        render(
+          html`${map(
+            rollables,
+            (meter) => html`
+              <li @click=${() => this.options.onMakeMove?.(this.move, meter)}>
+                <dl>
+                  <dt data-value=${meter.definition.label}>
+                    ${meter.definition.label}
+                  </dt>
+                  <dd data-value=${meter.value}>
+                    <span
+                      ${ref((el) => el && setIcon(el as HTMLElement, "dice"))}
+                    ></span>
+                    <span>+</span>
+                    <span>${meter.value}</span>
+                  </dd>
+                </dl>
+              </li>
+            `,
+          )}`,
+          rollsList,
+        );
+      }
+      new ButtonComponent(moveButtonsEl)
+        .setButtonText("Make this move with prompts")
+        .onClick(() => this.options.onMakeMove?.(this.move));
+    }
+
     const { moveText, oracles } = await this.getMoveText(this.move);
+
+    // Render the move text
     await MarkdownRenderer.render(
       this.plugin.app,
       moveText,
-      this.containerEl.createEl("div", { cls: "md-wrapper" }),
+      this.containerEl,
       ".", // TODO: i can make this an optional constructor param
       this,
     );
+
+    // Render oracles
+    if (this.options.showOracles) {
+      for (const { oracleText, oracle } of oracles) {
+        if (this.options.onRollOracle) {
+          const callback = this.options.onRollOracle;
+          new ButtonComponent(this.containerEl)
+            .setButtonText(`Roll ${oracle.name}`)
+            .setTooltip(`Roll on the ${oracle.name} oracle.`)
+            .onClick(() => callback(oracle));
+        }
+        await MarkdownRenderer.render(
+          this.plugin.app,
+          oracleText,
+          this.containerEl.createEl("div", { cls: "md-wrapper" }),
+          ".",
+          this,
+        );
+      }
+    }
+
+    const onClickDataswornLink = this.options.onClickDataswornLink;
+    if (onClickDataswornLink) {
+      console.debug("MoveRenderer: adding click handlers for links");
+      for (const child of this.containerEl.querySelectorAll(
+        "a[data-datasworn-id]",
+      )) {
+        if (!(child instanceof HTMLAnchorElement)) continue;
+
+        child.addEventListener("click", (ev) => {
+          const id = (ev.currentTarget as HTMLAnchorElement).dataset
+            .dataswornId;
+          if (!id) return;
+          onClickDataswornLink(id, ev);
+        });
+      }
+    }
   }
 
   async getMoveText(move: AnyDataswornMove) {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -66,6 +66,9 @@ export class IronVaultPluginSettings {
   /** Allow clicking through the dice. */
   diceAllowClickthrough: boolean = false;
 
+  /** Whether to use new style move sidebar or revert to legacy move modal. */
+  useLegacyMoveModal: boolean = false;
+
   emitter?: Emittery;
 
   constructor() {

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -424,5 +424,18 @@ export class IronVaultSettingTab extends PluginSettingTab {
           .setValue(settings.alwaysRecordActor)
           .onChange((value) => this.updateSetting("alwaysRecordActor", value)),
       );
+
+    new Setting(containerEl).setName("Legacy").setHeading();
+
+    new Setting(containerEl)
+      .setName("Disable embedding moves in sidebar")
+      .setDesc(
+        "If enabled, revert to old Iron Vault behavior of including only the name and trigger text in the sidebar. Clicking on move links will open in a move modal instead of sidebar.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(settings.useLegacyMoveModal)
+          .onChange((value) => this.updateSetting("useLegacyMoveModal", value)),
+      );
   }
 }

--- a/src/sidebar/css/moves.css
+++ b/src/sidebar/css/moves.css
@@ -1,20 +1,18 @@
 .iron-vault-moves-list {
-  & .ruleset {
-    & > .wrapper > details span {
+  & li.ruleset {
+    & > details > summary {
       font-size: 1.4em;
       border-bottom: 1px solid var(--background-secondary);
     }
     background-color: var(--background-secondary);
-    & > .wrapper {
-      & > .content {
-        padding: 0;
-      }
+    & > .content {
+      padding: 0;
     }
-    & li:has(+ li) {
+    &:has(+ li) {
       border-bottom: 1px solid var(--background-secondary);
     }
   }
-  & .move-category li {
+  & .move-category li.move-item {
     display: flex;
     flex-direction: column;
     padding: 0.5em;
@@ -25,9 +23,13 @@
       margin-top: 0.2em;
       color: var(--text-muted);
     }
-    & > :first-child {
+    & > details > summary,
+    & > header {
       font-size: 1.2em;
       font-weight: var(--font-semibold);
+      &:hover {
+        cursor: pointer;
+      }
     }
     &:has(+ li) {
       border-bottom: 1px solid var(--background-secondary-alt);
@@ -39,7 +41,7 @@
       background-color: var(--background-modifier-active-hover);
     }
   }
-  & .ruleset > .wrapper > .content {
+  & .ruleset > .content {
     padding: 0 !important;
   }
 }

--- a/src/sidebar/css/sidebar.css
+++ b/src/sidebar/css/sidebar.css
@@ -14,6 +14,7 @@
 }
 
 .iron-vault-sidebar-view {
+  font-size: var(--font-ui-small);
   & .character-tab > .markdown-wrapper > p > .markdown-embed {
     --embed-padding: 1em;
   }

--- a/src/sidebar/css/tab-content-shared.css
+++ b/src/sidebar/css/tab-content-shared.css
@@ -17,30 +17,26 @@
   height: 2em;
   font-size: 1.2em;
 }
-.iron-vault-moves-list,
-.iron-vault-oracles-list,
-.iron-vault-asset-list {
+ul.iron-vault-moves-list,
+ul.iron-vault-oracles-list,
+ul.iron-vault-asset-list {
   margin: 0;
   padding: 0;
   padding-left: 0 !important;
   list-style-type: none;
-  & ul,
-  ol {
-    margin: 0;
-    padding: 0;
-    list-style-type: none;
-  }
   background-color: var(--background-primary-alt);
-  & summary > span {
-    transition: background-color 200ms ease;
-    &:hover {
-      background-color: var(--background-modifier-hover);
-    }
-    &:active {
-      background-color: var(--background-modifier-active-hover);
-    }
-  }
+
   & details:has(+ .content) {
+    & > summary > span {
+      transition: background-color 200ms ease;
+      &:hover {
+        background-color: var(--background-modifier-hover);
+      }
+      &:active {
+        background-color: var(--background-modifier-active-hover);
+      }
+    }
+
     max-width: 100%;
     overflow: hidden;
     & > summary {
@@ -50,22 +46,23 @@
       &::marker {
         display: none;
       }
-    }
-    & span {
-      position: relative;
-      padding: 0.5em;
-      display: flex;
-      align-items: center;
-      &:hover {
-        cursor: pointer;
-      }
-      &::before {
-        content: "►";
-        font-size: 1rem;
+
+      & span {
+        position: relative;
+        padding: 0.5em;
         display: flex;
         align-items: center;
-        margin-right: 0.5rem;
-        transition: rotate 100ms 100ms ease-out;
+        &:hover {
+          cursor: pointer;
+        }
+        &::before {
+          content: "►";
+          font-size: 1rem;
+          display: flex;
+          align-items: center;
+          margin-right: 0.5rem;
+          transition: rotate 100ms 100ms ease-out;
+        }
       }
     }
   }
@@ -87,7 +84,7 @@
         border 0ms linear;
       padding: 0.5em;
     }
-    & span::before {
+    & > summary > span::before {
       rotate: 90deg;
       transition: rotate 100ms ease-out;
     }

--- a/src/sidebar/moves.ts
+++ b/src/sidebar/moves.ts
@@ -1,82 +1,157 @@
-import { Move, MoveCategory } from "@datasworn/core/dist/Datasworn";
+import { MoveCategory } from "@datasworn/core/dist/Datasworn";
 import { html, render } from "lit-html";
 import { map } from "lit-html/directives/map.js";
 import MiniSearch from "minisearch";
 
+import { CampaignDataContext } from "campaigns/context";
+import { currentActiveCharacterForCampaign } from "character-tracker";
+import {
+  IActionContext,
+  NoCharacterActionConext,
+} from "characters/action-context";
 import { IDataContext } from "datastore/data-context";
 import { AnyDataswornMove } from "datastore/datasworn-indexer";
 import IronVaultPlugin from "index";
+import { ref } from "lit-html/directives/ref.js";
+import { runMoveCommand } from "moves/action";
 import { MoveModal, MoveRenderer } from "moves/move-modal";
-import { Component } from "obsidian";
+import { Component, MarkdownView } from "obsidian";
+import { runOracleCommand } from "oracles/command";
 import { md } from "utils/ui/directives";
 
 export type IronVaultMoveRendererOptions = {
   embed?: boolean;
-  embedParent?: Component;
 };
 
-export default function renderIronVaultMoves(
-  cont: HTMLElement,
-  plugin: IronVaultPlugin,
-  dataContext: IDataContext,
-  options: IronVaultMoveRendererOptions = {},
-) {
-  litHtmlMoveList(cont, plugin, dataContext, makeIndex(dataContext), options);
-}
+export class MoveList extends Component {
+  contentEl: HTMLElement;
+  index?: MiniSearch;
+  dataContext?: IDataContext;
+  targetView?: MarkdownView;
+  actionContext: IActionContext | undefined;
+  filter: string = "";
 
-function litHtmlMoveList(
-  cont: HTMLElement,
-  plugin: IronVaultPlugin,
-  dataContext: IDataContext,
-  searchIdx: MiniSearch<Move>,
-  options: IronVaultMoveRendererOptions = {},
-  filter?: string,
-) {
-  const results = filter
-    ? searchIdx.search(filter)
-    : [...dataContext.moves.values()].map((m) => ({ id: m._id }));
-  const categories = dataContext.moveCategories.values();
-  let total = 0;
-  const sources: Record<string, MoveCategory[]> = {};
-  for (const cat of categories) {
-    const contents = Object.values(cat.contents ?? {});
-    const filtered = contents.filter((m) =>
-      results.find((res) => m._id === res.id),
-    );
-    if (filtered.length) {
-      if (!sources[cat._source.title]) {
-        sources[cat._source.title] = [];
-      }
-      sources[cat._source.title].push({
-        ...cat,
-        contents: Object.fromEntries(filtered.map((m) => [m._id, m])),
-      });
-      total += filtered.length;
-    }
+  constructor(
+    containerEl: HTMLElement,
+    readonly plugin: IronVaultPlugin,
+    readonly options: IronVaultMoveRendererOptions = {},
+  ) {
+    super();
+    this.contentEl = containerEl.createDiv({
+      cls: "iron-vault-move-list-container",
+    });
   }
-  const tpl = html`
-    <input
-      class="search-box"
-      type="search"
-      placeholder="Filter moves..."
-      @input=${(e: Event) => {
-        const input = e.target as HTMLInputElement;
-        litHtmlMoveList(
-          cont,
-          plugin,
-          dataContext,
-          searchIdx,
-          options,
-          input.value,
-        );
-      }}
-    />
-    <ul class="iron-vault-moves-list">
-      ${map(
-        Object.entries(sources),
-        ([source, sourceCats]) =>
-          html` <li class="ruleset">
-            <div class="wrapper">
+
+  shouldEmbed() {
+    return this.options.embed !== undefined
+      ? this.options.embed
+      : !this.plugin.settings.useLegacyMoveModal;
+  }
+
+  onload() {
+    this.render();
+  }
+
+  onunload() {
+    this.contentEl.remove();
+  }
+
+  scrollToMove(id: string) {
+    this.filter = "";
+    this.render();
+    const targetEl = this.contentEl.querySelector(
+      `li.move-item[data-datasworn-id="${id}"]`,
+    );
+    if (!targetEl) {
+      console.warn(`Move with id ${id} not found in the move list`);
+      return;
+    }
+
+    const targetDetails = targetEl.querySelector("details")!;
+    targetDetails.open = true; // Ensure the details element is open
+
+    // Note that currently the content for categories/rulesets is in an
+    // element ADJACENT to the details instead of inside it, so we look
+    // for an ancestor that has a details child.
+    let parentEl: Element | null | undefined =
+      targetEl.closest(":has(> details)");
+    while (parentEl && this.contentEl.contains(parentEl)) {
+      parentEl.querySelector("details")!.open = true;
+      parentEl = parentEl.parentElement?.closest(":has(> details)");
+    }
+
+    // setTimeout is necessary to ensure the scroll happens after the DOM update
+    // that opens the details element.
+    setTimeout(
+      () =>
+        targetDetails.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+          inline: "nearest",
+        }),
+      0,
+    );
+  }
+
+  async updateContext(
+    dataContext: IDataContext | undefined,
+    targetView: MarkdownView | undefined,
+  ) {
+    this.dataContext = dataContext;
+    this.targetView = targetView;
+    this.actionContext =
+      dataContext instanceof CampaignDataContext
+        ? (currentActiveCharacterForCampaign(this.plugin, dataContext) ??
+          new NoCharacterActionConext(dataContext))
+        : undefined;
+    this.index = dataContext && makeIndex(dataContext);
+    this.render();
+  }
+
+  render() {
+    if (!this.dataContext || !this.index) {
+      render(html`<p>No moves available.</p>`, this.contentEl);
+      return;
+    }
+
+    const results = this.filter
+      ? this.index.search(this.filter)
+      : [...this.dataContext.moves.values()].map((m) => ({ id: m._id }));
+    const categories = this.dataContext.moveCategories.values();
+    let total = 0;
+    const sources: Record<string, MoveCategory[]> = {};
+    for (const cat of categories) {
+      const contents = Object.values(cat.contents ?? {});
+      const filtered = contents.filter((m) =>
+        results.find((res) => m._id === res.id),
+      );
+      if (filtered.length) {
+        if (!sources[cat._source.title]) {
+          sources[cat._source.title] = [];
+        }
+        sources[cat._source.title].push({
+          ...cat,
+          contents: Object.fromEntries(filtered.map((m) => [m._id, m])),
+        });
+        total += filtered.length;
+      }
+    }
+    const tpl = html`
+      <input
+        class="search-box"
+        type="search"
+        placeholder="Filter moves..."
+        @input=${(e: Event) => {
+          const input = e.target as HTMLInputElement;
+          this.filter = input.value.trim();
+          this.render();
+        }}
+      />
+      <ul class="iron-vault-moves-list">
+        ${map(
+          Object.entries(sources),
+          ([source, sourceCats]) =>
+            html`<li class="ruleset">
               <details open>
                 <summary>
                   <span>${source}</span>
@@ -84,29 +159,21 @@ function litHtmlMoveList(
               </details>
               <ul class="content">
                 ${map(sourceCats, (cat) =>
-                  renderCategory(plugin, dataContext, cat, total <= 5, options),
+                  this.renderCategory(cat, total <= 5),
                 )}
               </ul>
-            </div>
-          </li>`,
-      )}
-    </ul>
-  `;
-  render(tpl, cont);
-}
+            </li>`,
+        )}
+      </ul>
+    `;
+    render(tpl, this.contentEl);
+  }
 
-function renderCategory(
-  plugin: IronVaultPlugin,
-  dataContext: IDataContext,
-  category: MoveCategory,
-  open: boolean,
-  options: IronVaultMoveRendererOptions,
-) {
-  return html` <li
-    class="move-category"
-    style=${category.color ? `border-left: 6px solid ${category.color}` : ""}
-  >
-    <div class="wrapper">
+  renderCategory(category: MoveCategory, open: boolean) {
+    return html` <li
+      class="move-category"
+      style=${category.color ? `border-left: 6px solid ${category.color}` : ""}
+    >
       <details ?open=${open}>
         <summary>
           <span>${category.canonical_name ?? category.name}</span>
@@ -116,53 +183,85 @@ function renderCategory(
         ${map(
           Object.values(category.contents ?? {}),
           (move) =>
-            html`${renderMove(
-              plugin,
-              dataContext,
-              dataContext.moves.get(move._id)!,
-              options,
-            )}`,
+            html`${this.renderMove(this.dataContext!.moves.get(move._id)!)}`,
         )}
       </ol>
-    </div>
-  </li>`;
-}
+    </li>`;
+  }
 
-function renderMove(
-  plugin: IronVaultPlugin,
-  dataContext: IDataContext,
-  move: AnyDataswornMove,
-  options: IronVaultMoveRendererOptions,
-) {
-  if (options.embed) {
-    return html`
-      <li>
-        <header>${move.name}</header>
-        <div
-          ref=${(el: HTMLElement) =>
-            el &&
-            MoveRenderer.render(
-              plugin,
-              dataContext,
+  renderMove(move: AnyDataswornMove) {
+    if (this.shouldEmbed()) {
+      let renderer: MoveRenderer | undefined;
+      const callback = async (el?: Element) => {
+        if (el instanceof HTMLElement) {
+          if (!renderer) {
+            renderer = await MoveRenderer.render(
+              el,
+              this.plugin,
+              this.dataContext!,
               move,
-              options.embedParent!,
-            )}
-        ></div>
-      </li>
-    `;
-  } else {
-    return html`
-      <li
-        @click=${(ev: Event) => {
-          ev.preventDefault();
-          ev.stopPropagation();
-          new MoveModal(plugin.app, plugin, dataContext, move).open();
-        }}
-      >
-        <header>${move.name}</header>
-        ${md(plugin, move.trigger.text)}
-      </li>
-    `;
+              this,
+              {
+                showOracles: true,
+                actionContext: this.actionContext,
+                onMakeMove:
+                  this.targetView &&
+                  ((move, rollable) => {
+                    runMoveCommand(
+                      this.plugin,
+                      this.targetView!.editor,
+                      this.targetView!,
+                      move,
+                      rollable,
+                    );
+                  }),
+                onRollOracle:
+                  this.targetView &&
+                  ((oracle) => {
+                    runOracleCommand(
+                      this.plugin,
+                      this.targetView!.editor,
+                      this.targetView!,
+                      oracle,
+                    );
+                  }),
+              },
+            );
+          }
+        } else if (renderer) {
+          this.removeChild(renderer);
+          renderer = undefined;
+        }
+      };
+      return html`
+        <li class="move-item" data-datasworn-id="${move._id}">
+          <details>
+            <summary>${move.name}</summary>
+            <div ${ref(callback)}></div>
+          </details>
+        </li>
+      `;
+    } else {
+      return html`
+        <li
+          class="move-item"
+          data-datasworn-id="${move._id}"
+          @click=${(ev: Event) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            new MoveModal(
+              this.plugin.app,
+              this.plugin,
+              this.dataContext!,
+              move,
+            ).open();
+          }}
+        >
+          <header>${move.name}</header>
+          ${md(this.plugin, move.trigger.text)}
+        </li>
+      `;
+    }
   }
 }
 

--- a/src/sidebar/sidebar-block.ts
+++ b/src/sidebar/sidebar-block.ts
@@ -11,7 +11,10 @@ export default function registerSidebarBlocks(plugin: IronVaultPlugin) {
   plugin.registerMarkdownCodeBlockProcessor(
     "iron-vault-moves",
     (_source, el: HTMLElement, ctx) => {
-      ctx.addChild(new MovesRenderer(el, plugin, ctx.sourcePath));
+      ctx.addChild(
+        // TODO:configure embed based on block
+        new MovesRenderer(el, plugin, ctx.sourcePath, { embed: true }),
+      );
     },
   );
 
@@ -24,8 +27,19 @@ export default function registerSidebarBlocks(plugin: IronVaultPlugin) {
 }
 
 class MovesRenderer extends CampaignDependentBlockRenderer {
+  constructor(
+    containerEl: HTMLElement,
+    readonly plugin: IronVaultPlugin,
+    sourcePath?: string,
+    readonly options: {
+      embed?: boolean;
+    } = {},
+  ) {
+    super(containerEl, plugin, sourcePath);
+  }
+
   render(context: CampaignDataContext) {
-    renderIronVaultMoves(this.containerEl, this.plugin, context);
+    renderIronVaultMoves(this.containerEl, this.plugin, context, this.options);
   }
 }
 

--- a/src/sidebar/sidebar-block.ts
+++ b/src/sidebar/sidebar-block.ts
@@ -2,7 +2,7 @@ import { CampaignDependentBlockRenderer } from "campaigns/campaign-source";
 import { CampaignDataContext } from "campaigns/context";
 import IronVaultPlugin from "index";
 import { rootLogger } from "logger";
-import renderIronVaultMoves from "./moves";
+import { MoveList } from "./moves";
 import renderIronVaultOracles from "./oracles";
 
 export const logger = rootLogger.getLogger("sidebar-block");
@@ -27,6 +27,7 @@ export default function registerSidebarBlocks(plugin: IronVaultPlugin) {
 }
 
 class MovesRenderer extends CampaignDependentBlockRenderer {
+  moveList: MoveList;
   constructor(
     containerEl: HTMLElement,
     readonly plugin: IronVaultPlugin,
@@ -36,10 +37,12 @@ class MovesRenderer extends CampaignDependentBlockRenderer {
     } = {},
   ) {
     super(containerEl, plugin, sourcePath);
+    this.moveList = this.addChild(new MoveList(containerEl, plugin, options));
   }
 
   render(context: CampaignDataContext) {
-    renderIronVaultMoves(this.containerEl, this.plugin, context, this.options);
+    // TODO: this needs to figure out the current view
+    this.moveList.updateContext(context, undefined);
   }
 }
 


### PR DESCRIPTION
This changes the moves sidebar to entirely embed the text of moves. Clicking on a move link reveals the sidebar and scrolls to the appropriate move, instead of opening the move modal.

Since this change is still a bit rough around the edges, this also adds a setting _Disable embedding moves in sidebar_ which reverts to the prior modal-centric behavior for the sidebar and for move links.

This accomplishes one-half of issue #476.