### PR TITLE
Use details block for prompts

### DIFF
--- a/packages/obsidian/src/mechanics/css/details.css
+++ b/packages/obsidian/src/mechanics/css/details.css
@@ -4,13 +4,34 @@
 .iron-vault-mechanics .detail {
   color: var(--text-muted);
   --blockquote-background-color: var(--background-secondary);
-  --blockquote-color: var(--text-muted);
-  border-radius: 10px;
-  & .markdown-wrapper > :first-child {
+  background-color: var(--blockquote-background-color);
+
+  border-inline-start: var(--blockquote-border-thickness) solid
+    var(--blockquote-border-color);
+  padding-inline-start: var(--size-4-6);
+  margin-left: 0.5em;
+  padding-left: 1.2em;
+
+  /* First child is the comment text */
+  & > :first-child {
+    display: block;
+    font-style: italic;
+  }
+
+  & > :not(:first-child) {
+    border-inline-start: var(--blockquote-border-thickness) dashed
+      var(--blockquote-border-color);
+    padding-inline-start: var(--size-4-6);
+    margin-left: 0.5em;
+    padding-left: 1.2em;
+  }
+
+  /* border-radius: 10px; */
+  /* & .markdown-wrapper > :first-child {
     margin-left: 0.5em;
     padding-left: 1.2em;
   }
   & .markdown-wrapper > :first-child:not(blockquote) {
     display: inline;
-  }
+  } */
 }

--- a/packages/obsidian/src/mechanics/mechanics-blocks.ts
+++ b/packages/obsidian/src/mechanics/mechanics-blocks.ts
@@ -1,4 +1,4 @@
-import { html, render, TemplateResult } from "lit-html";
+import { html, nothing, render, TemplateResult } from "lit-html";
 import { ref } from "lit-html/directives/ref.js";
 import { styleMap } from "lit-html/directives/style-map.js";
 import {
@@ -394,7 +394,12 @@ See https://kdl.dev for syntax.</pre
       class="detail"
       @contextmenu=${this.makeMenuHandler(node)}
     >
-      ${md(this.plugin, "> " + details.join("\n> "))}
+      ${md(this.plugin, details.join("\n"))}
+      ${node.children.length > 0
+        ? html`<div ${ref((el) => makeSortable(el, node))}>
+            ${this.renderChildren(node.children)}
+          </div>`
+        : nothing}
     </aside>`;
   }
 

--- a/packages/obsidian/src/mechanics/node-builders/index.ts
+++ b/packages/obsidian/src/mechanics/node-builders/index.ts
@@ -124,7 +124,6 @@ export function createOracleNode(
   const baseResult = node("oracle", {
     properties: props,
     children: [
-      ...(prompt ? [node("-", { values: [prompt] })] : []),
       ...Object.values(roll.subrolls)
         .flatMap((subroll) => subroll.rolls)
         .map((subroll) => createOracleNode(subroll)),
@@ -135,7 +134,17 @@ export function createOracleNode(
     baseResult.properties.replaced =
       cursedResult.oracle.curseBehavior === CurseBehavior.ReplaceResult;
   }
-  return baseResult;
+  return wrapWithPrompt(prompt, baseResult);
+}
+
+/** If a prompt is provided, wrap the node in a details node. Otherwise, return just the node. */
+export function wrapWithPrompt(
+  prompt: string | undefined,
+  node: kdl.Node,
+): kdl.Node {
+  if (!prompt) return node;
+
+  return createDetailsNode(prompt, [node]);
 }
 
 export function generateActionRoll(move: ActionMoveDescription): kdl.Node {
@@ -230,9 +239,13 @@ export function createOracleGroup(
   });
 }
 
-export function createDetailsNode(details: string): kdl.Node {
+export function createDetailsNode(
+  details: string,
+  children: kdl.Node[] = [],
+): kdl.Node {
   return node("-", {
     values: [details],
+    children,
   });
 }
 


### PR DESCRIPTION
Instead of nesting the prompt in the oracle block, this reverses it, so that the prompt details node is the parent of the oracle block. In future iterations, we can probably make these detail blocks collapsible, etc.