### PR TITLE
Expose entity funcs in API

### DIFF
--- a/packages/datasworn-compiler/src/builder.ts
+++ b/packages/datasworn-compiler/src/builder.ts
@@ -270,7 +270,7 @@ export class ContentIndexer {
   async indexFile(
     path: string,
     mtime: number,
-    hash: Uint8Array<ArrayBuffer>,
+    hash: Uint8Array,
     data: string,
     frontmatter: Record<string, unknown> | undefined,
   ): Promise<void> {

--- a/packages/obsidian/src/api.ts
+++ b/packages/obsidian/src/api.ts
@@ -1,6 +1,16 @@
 import { CampaignDataContext } from "campaigns/context";
 import { CharacterActionContext } from "characters/action-context";
 import { IDataContext } from "datastore/data-context";
+import {
+  availableEntityTypes,
+  generateEntityViaModal,
+  promptForEntityType,
+} from "entity/command";
+import {
+  EntityDescriptor,
+  EntitySpec,
+  NewEntityModalResults,
+} from "entity/specs";
 import { rootLogger, setLogLevel } from "logger";
 import loglevel from "loglevel";
 import { App, getLinkpath, parseLinktext } from "obsidian";
@@ -48,6 +58,14 @@ export class IronVaultAPI {
     return this.activeCampaignContext ?? this.globalDataContext;
   }
 
+  mustActiveCampaignContext(): CampaignDataContext {
+    const context = this.activeCampaignContext;
+    if (!context) {
+      throw new Error("No active campaign context available.");
+    }
+    return context;
+  }
+
   /** Prompt the user to select a character for the given campaign context.
    * @returns promise that resolves to CharacterActionContext for the selected character, or fails
    *   if the user cancels.
@@ -68,6 +86,74 @@ export class IronVaultAPI {
     const campaign = campaignContext ?? this.activeCampaignContext;
     return (
       campaign && currentActiveCharacterForCampaign(this.plugin, campaign, true)
+    );
+  }
+
+  /** Returns the available entity types for the given campaign context. */
+  availableEntityTypes(
+    campaignContext: CampaignDataContext = this.mustActiveCampaignContext(),
+  ): [string, EntityDescriptor<EntitySpec>][] {
+    return availableEntityTypes(campaignContext);
+  }
+
+  /** Get the entity descriptor for the given entity type. */
+  getEntityDescriptor(
+    entityType: string,
+    campaignContext: CampaignDataContext = this.mustActiveCampaignContext(),
+  ): EntityDescriptor<EntitySpec> | undefined {
+    const entityTypes = this.availableEntityTypes(campaignContext);
+    const found = entityTypes.find(([type]) => type === entityType);
+    return found ? found[1] : undefined;
+  }
+
+  /** Prompts for an entity type and returns the entity descriptor for the selected entity type.
+   *
+   * @param campaignContext - the campaign context to use for available entity types. if not provided,
+   *  the currently active campaign context is used. if no active campaign, an error is thrown.
+   * @returns a promise that resolves to the selected entity descriptor.
+   */
+  promptForEntityType(
+    campaignContext: CampaignDataContext = this.mustActiveCampaignContext(),
+  ): Promise<EntityDescriptor<EntitySpec>> {
+    return promptForEntityType(this.plugin, campaignContext);
+  }
+
+  /** Generates an entity.
+   *
+   * @param entityDesc - the entity descriptor to use for generating the entity, as returned by
+   * `promptForEntityType` or `availableEntityTypes`. If not provided, {@link promptForEntityType}
+   * will be called to prompt the user for an entity type.
+   * @param campaignContext - the campaign context to use for generating the entity. if not provided,
+   *  the currently active campaign context is used. if no active campaign, an error is thrown.
+   * @returns a promise that resolves to the results of the entity generation modal.
+   *
+   * @remarks
+   * This method will prompt the user to select an entity type if `entityDesc` is not provided.
+   * It will then open a modal to generate the entity based on the selected type.
+   *
+   * @example <caption>Using a specific entity type</caption>
+   * // Must be run within a SF campaign context
+   * const ed = IronVaultAPI.getEntityDescriptor("sfPlanet");
+   * const entity = await IronVaultAPI.generateEntity(ed);
+   * for (const [k, v] of Object.entries(entity.entityProxy)) {
+   *   console.log(k, "=", v.map((roll) => roll.simpleResult).join("; "));
+   * }
+   * // region = Expanse
+   * // class = [Rocky World](datasworn:oracle_collection:starforged/planet/rocky)
+   * // name = Latona
+   * // atmosphere = None / thin
+   * // observed_from_space = [Precursor Vault](datasworn:oracle_collection:starforged/precursor_vault) (orbital)
+   * // settlements = None
+   */
+  async generateEntity(
+    entityDesc: EntityDescriptor<EntitySpec> | undefined = undefined,
+    campaignContext: CampaignDataContext = this.mustActiveCampaignContext(),
+  ): Promise<NewEntityModalResults<EntitySpec>> {
+    entityDesc ??= await this.promptForEntityType(campaignContext);
+    return await generateEntityViaModal(
+      this.plugin,
+      campaignContext,
+      entityDesc,
     );
   }
 

--- a/packages/obsidian/src/mechanics/commands.ts
+++ b/packages/obsidian/src/mechanics/commands.ts
@@ -1,4 +1,4 @@
-import { Editor, MarkdownFileInfo } from "obsidian";
+import { Editor, MarkdownFileInfo, Notice } from "obsidian";
 
 import {
   DiceExprGroup,

--- a/packages/obsidian/src/utils/dice-overlay.ts
+++ b/packages/obsidian/src/utils/dice-overlay.ts
@@ -170,7 +170,7 @@ async function ensureAssets(plugin: IronVaultPlugin) {
     const dest = normalizePath(assetsPath + "/" + path);
     return plugin.app.vault.adapter.mkdir(dest);
   }
-  function writeFile(path: string, data: Uint8Array | string) {
+  function writeFile(path: string, data: Uint8Array<ArrayBuffer> | string) {
     const dest = normalizePath([assetsPath, path].join("/"));
     if (typeof data === "string") {
       return plugin.app.vault.adapter.write(dest, data);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ catalogs:
       specifier: ^20.17.24
       version: 20.19.7
     '@types/obsidian-typings':
-      specifier: npm:obsidian-typings@^2.35.0
-      version: 2.44.3
+      specifier: npm:obsidian-typings@^3.12.1
+      version: 3.12.1
     '@types/semver':
       specifier: ^7.7.0
       version: 7.7.0
@@ -457,7 +457,7 @@ importers:
         version: 20.19.7
       '@types/obsidian-typings':
         specifier: 'catalog:'
-        version: obsidian-typings@2.44.3(@codemirror/view@6.38.0)(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/utils@7.2.4)
+        version: obsidian-typings@3.12.1(@codemirror/view@6.38.0)(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(typescript@5.8.3)
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.0
@@ -642,6 +642,9 @@ packages:
 
   '@antfu/utils@8.1.1':
     resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
+
+  '@antfu/utils@9.2.0':
+    resolution: {integrity: sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1124,36 +1127,20 @@ packages:
   '@ophidian/electron-types@24.3.1':
     resolution: {integrity: sha512-fzvB7sQMxTbQHbp3rcYIxaqHiWjFnpSBVvZBSDH0Rq0xMvihBH1D4/O2JqybSlVpYtbvXR4nVKeH3w4JmHLTag==}
 
-  '@pixi/accessibility@7.2.4':
-    resolution: {integrity: sha512-EVjuqUqv9FeYFXCv0S0qj1hgCtbAMNBPCbOGEtiMogpM++/IySxBZvcOYg3rRgo9inwt2s4Bi7kUiqMPD8hItw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/events': 7.2.4
-
-  '@pixi/app@7.2.4':
-    resolution: {integrity: sha512-eJ2jpu5P28ip07nLItw6sETXn45P4KR/leMJ6zPHRlhT1m8t5zTsWr3jK4Uj8LF2E+6KlPNzLQh5Alf/unn/aQ==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-
-  '@pixi/assets@7.2.4':
-    resolution: {integrity: sha512-7199re3wvMAlVqXLaCyAr8IkJSXqkeVAxcYyB2rBu4Id5m2hhlGX1dQsdMBiCXLwu6/LLVqDvJggSNVQBzL6ZQ==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/utils': 7.2.4
-
   '@pixi/color@7.2.4':
     resolution: {integrity: sha512-B/+9JRcXe2uE8wQfsueFRPZVayF2VEMRB7XGeRAsWCryOX19nmWhv0Nt3nOU2rvzI0niz9XgugJXsB6vVmDFSg==}
 
-  '@pixi/compressed-textures@7.2.4':
-    resolution: {integrity: sha512-atnWyw/ot/Wg69qhgskKiuTYCZx15IxV35sa0KyXMthyjyvDLCIvOn0nczM6wCBy9H96SjJbfgynVWhVrip6qw==}
-    peerDependencies:
-      '@pixi/assets': 7.2.4
-      '@pixi/core': 7.2.4
+  '@pixi/color@7.4.3':
+    resolution: {integrity: sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==}
+
+  '@pixi/colord@2.9.6':
+    resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
 
   '@pixi/constants@7.2.4':
     resolution: {integrity: sha512-hKuHBWR6N4Q0Sf5MGF3/9l+POg/G5rqhueHfzofiuelnKg7aBs3BVjjZ+6hZbd6M++vOUmxYelEX/NEFBxrheA==}
+
+  '@pixi/constants@7.4.3':
+    resolution: {integrity: sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==}
 
   '@pixi/core@7.2.4':
     resolution: {integrity: sha512-0XtvrfxHlS2T+beBBSpo7GI8+QLyyTqMVQpNmPqB4woYxzrOEJ9JaUFBaBfCvycLeUkfVih1u6HAbtF+2d1EjQ==}
@@ -1163,104 +1150,17 @@ packages:
     peerDependencies:
       '@pixi/core': 7.2.4
 
-  '@pixi/events@7.2.4':
-    resolution: {integrity: sha512-/JtmoB98fzIU8giN9xvlRvmvOi6u4MaD2DnKNOMHkQ1MBraj3pmrXM9fZ0JbNzi+324GraAAY76QidgHjIYoYQ==}
+  '@pixi/events@7.4.3':
+    resolution: {integrity: sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==}
     peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
 
   '@pixi/extensions@7.2.4':
     resolution: {integrity: sha512-Mnqv9scbL1ARD3QFKfOWs2aSVJJfP1dL8g5UiqGImYO3rZbz/9QCzXOeMVIZ5n3iaRyKMNhFFr84/zUja2H7Dw==}
 
-  '@pixi/extract@7.2.4':
-    resolution: {integrity: sha512-wlXZg+J2L/1jQhRi5nZQP/cXshovhjksjss91eAKMvY5aGxNAQovCP4xotJ/XJjfTvPMpeRzHPFYzm3PrOPQ7g==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-alpha@7.2.4':
-    resolution: {integrity: sha512-UTUMSGyktUr+I9vmigqJo9iUhb0nwGyqTTME2xBWZvVGCnl5z+/wHxvIBBCe5pNZ66IM15pGXQ4cDcfqCuP2kA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-blur@7.2.4':
-    resolution: {integrity: sha512-aLyXIoxy14bTansCPtbY8x7Sdn2OrrqkF/pcKiRXHJGGhi7wPacvB/NcmYJdnI/n2ExQ6V5Njuj/nfrsejVwcA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-color-matrix@7.2.4':
-    resolution: {integrity: sha512-DFtayybYXoUh73eHUFRK5REbi1t3FZuVUnaQTj+euHKF9L7EaYc3Q9wctpx1WPRcwkqEX50M4SNFhxpA7Pxtaw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-displacement@7.2.4':
-    resolution: {integrity: sha512-Simq3IBJKt7+Gvk4kK7OFkfoeYUMhNhIyATCdeT+Jkdkq5WV7pYnH5hqO0YW7eAHrgjV13yn6t4H/GC4+6LhEA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-fxaa@7.2.4':
-    resolution: {integrity: sha512-qzKjdL+Ih18uGTJLg8tT/H+YCsTeGkw2uF7lyKnw/lxGLJQhLWIhM95M9qSNgxbXyW1vp7SbG81a9aAEz2HAhA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-noise@7.2.4':
-    resolution: {integrity: sha512-QAU9Ybj2ZQrWM9ZEjTTC0iLnQcuyNoZNRinxSbg1G0yacpmsSb9wvV5ltIZ66+hfY+90+u2Nudt/v9g6pvOdGg==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/graphics@7.2.4':
-    resolution: {integrity: sha512-3A2EumTjWJgXlDLOyuBrl9b6v1Za/E+/IjOGUIX843HH4NYaf1a2sfDfljx6r3oiDvy+VhuBFmgynRcV5IyA0Q==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/sprite': 7.2.4
-
   '@pixi/math@7.2.4':
     resolution: {integrity: sha512-LJB+mozyEPllxa0EssFZrKNfVwysfaBun4b2dJKQQInp0DafgbA0j7A+WVg0oe51KhFULTJMpDqbLn/ITFc41A==}
-
-  '@pixi/mesh-extras@7.2.4':
-    resolution: {integrity: sha512-Lxqq/1E2EmDgjZX8KzjhBy3VvITIQ00arr2ikyHYF1d0XtQTKEYpr8VKzhchqZ5/9DuyTDbDMYGhcxoNXQmZrQ==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/mesh': 7.2.4
-
-  '@pixi/mesh@7.2.4':
-    resolution: {integrity: sha512-wiALIqcRKib2BqeH9kOA5fOKWN352nqAspgbDa8gA7OyWzmNwqIedIlElixd0oLFOrIN5jOZAdzeKnoYQlt9Aw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-
-  '@pixi/mixin-cache-as-bitmap@7.2.4':
-    resolution: {integrity: sha512-95L/9nzfLHw6GoeqqRl/RjSloKvRt0xrc2inCmjMZvMsFUEtHN2F8IWd1k5vcv0S+83NCreFkJg6nJm1m5AZqg==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/sprite': 7.2.4
-
-  '@pixi/mixin-get-child-by-name@7.2.4':
-    resolution: {integrity: sha512-9g17KgSBEEhkinnKk4dqmxagzHOCPSTvGB6lOopBq4yyXmr/2WVv+QGjuzE0O+p80szQeBJjPBQxzrfBILaSRw==}
-    peerDependencies:
-      '@pixi/display': 7.2.4
-
-  '@pixi/mixin-get-global-position@7.2.4':
-    resolution: {integrity: sha512-UrAUF2BXCeWtFgR2m+er41Ky7zShT7r228cZkB6ZfYwMeThhwqG5mH68UeCyP6p68JMpT1gjI2DPfeSRY3ecnA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-
-  '@pixi/particle-container@7.2.4':
-    resolution: {integrity: sha512-tpSzilZGFtAoi8XhzL0TecLPNRQAbY8nWV9XNGXJDw+nxXp18GCe8L6eEmnHLlAug67BRHl65DtrdvTknPX+4g==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/sprite': 7.2.4
-
-  '@pixi/prepare@7.2.4':
-    resolution: {integrity: sha512-Yff5Sh4kTLdKc5VkkM44LW9gpj7Izw8ns3P1TzWxqeGjzPZ3folr/tQujGL+Qw+8A9VESp+hX9MSIHyw+jpyrg==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/graphics': 7.2.4
-      '@pixi/text': 7.2.4
 
   '@pixi/runner@7.2.4':
     resolution: {integrity: sha512-YtyqPk1LA+0guEFKSFx6t/YSvbEQwajFwi4Ft8iDhioa6VK2MmTir1GjWwy7JQYLcDmYSAcQjnmFtVTZohyYSw==}
@@ -1268,53 +1168,8 @@ packages:
   '@pixi/settings@7.2.4':
     resolution: {integrity: sha512-ZPKRar9EwibijGmH8EViu4Greq1I/O7V/xQx2rNqN23XA7g09Qo6yfaeQpufu5xl8+/lZrjuHtQSnuY7OgG1CA==}
 
-  '@pixi/sprite-animated@7.2.4':
-    resolution: {integrity: sha512-9eRriPSC0QVS7U9zQlrG3uEI5+h3fi+mqofXy+yjk1sGCmXSIJME5p2wg2mzxoJk3qkSMagQA9QHtL26Fti8Iw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/sprite': 7.2.4
-
-  '@pixi/sprite-tiling@7.2.4':
-    resolution: {integrity: sha512-nGfxQoACRx49dUN0oW1vFm3141M+7gkAbzoNJym2Pljd2dpLME9fb5E6Lyahu0yWMaPRhhGorn6z9VIGmTF3Jw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/sprite': 7.2.4
-
-  '@pixi/sprite@7.2.4':
-    resolution: {integrity: sha512-DhR1B+/d0eXpxHIesJMXcVPrKFwQ+zRA1LvEIFfzewqfaRN3X6PMIuoKX8SIb6tl+Hq8Ba9Pe28zI7d2rmRzrA==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-
-  '@pixi/spritesheet@7.2.4':
-    resolution: {integrity: sha512-LNmlavyiMQeCF0U4S+yhzxUYmPmat6EpLjLnkGukQTZV5CZkxDCVgXM9uKoRF2DvNydj4yuwZ6+JjK8QssHI8Q==}
-    peerDependencies:
-      '@pixi/assets': 7.2.4
-      '@pixi/core': 7.2.4
-
-  '@pixi/text-bitmap@7.2.4':
-    resolution: {integrity: sha512-3u2CP4VN+muCaq/jtj7gn0hb3DET/X2S04zTBcgc2WVGufJc62yz+UDzS9jC+ellotVdt9c8U74++vpz3zJGfw==}
-    peerDependencies:
-      '@pixi/assets': 7.2.4
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/mesh': 7.2.4
-      '@pixi/text': 7.2.4
-
-  '@pixi/text-html@7.2.4':
-    resolution: {integrity: sha512-0NfLAE/w51ZtatxVqLvDS62iO0VLKsSdctqTAVv4Zlgdk9TKJmX1WUucHJboTvbm2SbDjNDGfZ6qXM5nAslIDQ==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4
-      '@pixi/sprite': 7.2.4
-      '@pixi/text': 7.2.4
-
-  '@pixi/text@7.2.4':
-    resolution: {integrity: sha512-DGu7ktpe+zHhqR2sG9NsJt4mgvSObv5EqXTtUxD4Z0li1gmqF7uktpLyn5I6vSg1TTEL4TECClRDClVDGiykWw==}
-    peerDependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/sprite': 7.2.4
+  '@pixi/settings@7.4.3':
+    resolution: {integrity: sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==}
 
   '@pixi/ticker@7.2.4':
     resolution: {integrity: sha512-hQQHIHvGeFsP4GNezZqjzuhUgNQEVgCH9+qU05UX1Mc5UHC9l6OJnY4VTVhhcHxZjA6RnyaY+1zBxCnoXuazpg==}
@@ -1496,6 +1351,9 @@ packages:
 
   '@types/codemirror@5.60.8':
     resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+
+  '@types/css-font-loading-module@0.0.12':
+    resolution: {integrity: sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==}
 
   '@types/css-font-loading-module@0.0.14':
     resolution: {integrity: sha512-+EwJ/RW2vPqbYn0JXRHy593huPCtgmLF/kg57iLK9KUn6neTqGGOTZ0CbssP8Uou/gqT/5XmWKQ8A7ve7xNV6A==}
@@ -1773,6 +1631,13 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@webgpu/types@0.1.64':
+    resolution: {integrity: sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==}
+
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2442,6 +2307,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -2575,6 +2443,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2681,8 +2552,13 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+  i18next@25.3.2:
+    resolution: {integrity: sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2858,6 +2734,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -3243,8 +3122,10 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  obsidian-typings@2.44.3:
-    resolution: {integrity: sha512-Q4H3XQ7OL7qF80fiba+Ihk9eYU8aip90J0zaYlOXUADhQeXPEP05LO9Dp9HDuh2908B16iJyUuxwgMwZ1oDtgA==}
+  obsidian-typings@3.12.1:
+    resolution: {integrity: sha512-Cmr+Az9WWnU6i62noa4yrHZ7xCvC6C8B+raS+TVeuNuOOIE8/D66NUEgnGAXfR4Vlq1mRifoegXYXMVZdI812w==}
+    peerDependencies:
+      typescript: '>=4.8.0'
 
   obsidian@1.8.7:
     resolution: {integrity: sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==}
@@ -3296,6 +3177,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -3351,8 +3235,8 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  pixi.js@7.2.4:
-    resolution: {integrity: sha512-nBH60meoLnHxoMFz17HoMxXS4uJpG5jwIdL+Gx2S11TzWgP3iKF+/WLOTrkSdyuQoQSdIBxVqpnYii0Wiox15A==}
+  pixi.js@8.9.2:
+    resolution: {integrity: sha512-oLFBkOOA/O6OpT5T8o05AxgZB9x9yWNzEQ+WTNZZFoCvfU2GdT4sFTjpVFuHQzgZPmAm/1IFhKdNiXVnlL8PRw==}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -4167,6 +4051,8 @@ snapshots:
 
   '@antfu/utils@8.1.1': {}
 
+  '@antfu/utils@9.2.0': {}
+
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -4604,33 +4490,19 @@ snapshots:
 
   '@ophidian/electron-types@24.3.1': {}
 
-  '@pixi/accessibility@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/events@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/events': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/app@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-
-  '@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/utils': 7.2.4
-      '@types/css-font-loading-module': 0.0.7
-
   '@pixi/color@7.2.4':
     dependencies:
       colord: 2.9.3
 
-  '@pixi/compressed-textures@7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)':
+  '@pixi/color@7.4.3':
     dependencies:
-      '@pixi/assets': 7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4)
-      '@pixi/core': 7.2.4
+      '@pixi/colord': 2.9.6
+
+  '@pixi/colord@2.9.6': {}
 
   '@pixi/constants@7.2.4': {}
+
+  '@pixi/constants@7.4.3': {}
 
   '@pixi/core@7.2.4':
     dependencies:
@@ -4648,86 +4520,14 @@ snapshots:
     dependencies:
       '@pixi/core': 7.2.4
 
-  '@pixi/events@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
+  '@pixi/events@7.4.3(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
     dependencies:
       '@pixi/core': 7.2.4
       '@pixi/display': 7.2.4(@pixi/core@7.2.4)
 
   '@pixi/extensions@7.2.4': {}
 
-  '@pixi/extract@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-alpha@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-blur@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-color-matrix@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-displacement@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-fxaa@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/filter-noise@7.2.4(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/core': 7.2.4
-
-  '@pixi/graphics@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
   '@pixi/math@7.2.4': {}
-
-  '@pixi/mesh-extras@7.2.4(@pixi/core@7.2.4)(@pixi/mesh@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/mesh': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/mesh@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-
-  '@pixi/mixin-cache-as-bitmap@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/mixin-get-child-by-name@7.2.4(@pixi/display@7.2.4(@pixi/core@7.2.4))':
-    dependencies:
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-
-  '@pixi/mixin-get-global-position@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-
-  '@pixi/particle-container@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/prepare@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/graphics@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/graphics': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/text': 7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
 
   '@pixi/runner@7.2.4': {}
 
@@ -4737,46 +4537,11 @@ snapshots:
       '@types/css-font-loading-module': 0.0.7
       ismobilejs: 1.1.1
 
-  '@pixi/sprite-animated@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
+  '@pixi/settings@7.4.3':
     dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/sprite-tiling@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-
-  '@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-
-  '@pixi/spritesheet@7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)':
-    dependencies:
-      '@pixi/assets': 7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4)
-      '@pixi/core': 7.2.4
-
-  '@pixi/text-bitmap@7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/mesh@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))':
-    dependencies:
-      '@pixi/assets': 7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4)
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/mesh': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/text': 7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-
-  '@pixi/text-html@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/text': 7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-
-  '@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))':
-    dependencies:
-      '@pixi/core': 7.2.4
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
+      '@pixi/constants': 7.4.3
+      '@types/css-font-loading-module': 0.0.12
+      ismobilejs: 1.1.1
 
   '@pixi/ticker@7.2.4':
     dependencies:
@@ -4921,7 +4686,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 20.19.7
+      '@types/node': 22.16.3
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.2':
@@ -4935,6 +4700,8 @@ snapshots:
   '@types/codemirror@5.60.8':
     dependencies:
       '@types/tern': 0.23.9
+
+  '@types/css-font-loading-module@0.0.12': {}
 
   '@types/css-font-loading-module@0.0.14': {}
 
@@ -5079,7 +4846,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 20.19.7
+      '@types/node': 22.16.3
 
   '@types/lodash.isequal@4.5.8':
     dependencies:
@@ -5119,7 +4886,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 20.19.7
+      '@types/node': 22.16.3
 
   '@types/semver@7.7.0': {}
 
@@ -5137,7 +4904,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.7
+      '@types/node': 22.16.3
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0)(typescript@5.8.3))(eslint@9.31.0)(typescript@5.8.3)':
@@ -5275,6 +5042,10 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.1.4
       tinyrainbow: 2.0.0
+
+  '@webgpu/types@0.1.64': {}
+
+  '@xmldom/xmldom@0.8.10': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -6088,6 +5859,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.1: {}
+
   expect-type@1.2.2: {}
 
   exsolve@1.0.7: {}
@@ -6246,6 +6019,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -6373,9 +6150,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  i18next@23.16.8:
+  i18next@25.3.2(typescript@5.8.3):
     dependencies:
       '@babel/runtime': 7.27.6
+    optionalDependencies:
+      typescript: 5.8.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -6547,6 +6326,8 @@ snapshots:
   jju@1.4.0: {}
 
   joycon@3.1.1: {}
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-tokens@9.0.1: {}
 
@@ -7125,34 +6906,37 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  obsidian-typings@2.44.3(@codemirror/view@6.38.0)(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/utils@7.2.4):
+  obsidian-typings@3.12.1(@codemirror/view@6.38.0)(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(typescript@5.8.3):
     dependencies:
+      '@antfu/utils': 9.2.0
       '@capacitor/core': 6.2.1
+      '@codemirror/language': 6.11.2
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
-      '@pixi/color': 7.2.4
-      '@pixi/events': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/settings': 7.2.4
+      '@lezer/common': 1.2.3
+      '@pixi/color': 7.4.3
+      '@pixi/events': 7.4.3(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
+      '@pixi/settings': 7.4.3
       '@types/codemirror': 5.60.16
       '@types/css-font-loading-module': 0.0.14
-      '@types/node': 20.19.7
+      '@types/node': 22.16.3
       '@types/prismjs': 1.26.5
       '@types/turndown': 5.0.5
       dompurify: 3.2.6
       electron: 37.2.1
-      i18next: 23.16.8
+      i18next: 25.3.2(typescript@5.8.3)
       mermaid: 11.8.1
       moment: 2.30.1
       obsidian: 1.8.7(@codemirror/state@6.5.2)(@codemirror/view@6.38.0)
       pdfjs-dist: 5.3.93
-      pixi.js: 7.2.4(@pixi/utils@7.2.4)
+      pixi.js: 8.9.2
       scrypt-js: 3.0.1
       style-mod: 4.1.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - '@codemirror/view'
       - '@pixi/core'
       - '@pixi/display'
-      - '@pixi/utils'
       - supports-color
 
   obsidian@1.8.7(@codemirror/state@6.5.2)(@codemirror/view@6.38.0):
@@ -7209,6 +6993,8 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-svg-path@0.1.2: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -7246,40 +7032,18 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  pixi.js@7.2.4(@pixi/utils@7.2.4):
+  pixi.js@8.9.2:
     dependencies:
-      '@pixi/accessibility': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/events@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/app': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/assets': 7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4)
-      '@pixi/compressed-textures': 7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)
-      '@pixi/core': 7.2.4
-      '@pixi/display': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/events': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/extensions': 7.2.4
-      '@pixi/extract': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-alpha': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-blur': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-color-matrix': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-displacement': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-fxaa': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/filter-noise': 7.2.4(@pixi/core@7.2.4)
-      '@pixi/graphics': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/mesh': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/mesh-extras': 7.2.4(@pixi/core@7.2.4)(@pixi/mesh@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/mixin-cache-as-bitmap': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/mixin-get-child-by-name': 7.2.4(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/mixin-get-global-position': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/particle-container': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/prepare': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/graphics@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))
-      '@pixi/sprite': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))
-      '@pixi/sprite-animated': 7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/sprite-tiling': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/spritesheet': 7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)
-      '@pixi/text': 7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))
-      '@pixi/text-bitmap': 7.2.4(@pixi/assets@7.2.4(@pixi/core@7.2.4)(@pixi/utils@7.2.4))(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/mesh@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))
-      '@pixi/text-html': 7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4)))(@pixi/text@7.2.4(@pixi/core@7.2.4)(@pixi/sprite@7.2.4(@pixi/core@7.2.4)(@pixi/display@7.2.4(@pixi/core@7.2.4))))
-    transitivePeerDependencies:
-      - '@pixi/utils'
+      '@pixi/colord': 2.9.6
+      '@types/css-font-loading-module': 0.0.12
+      '@types/earcut': 2.1.4
+      '@webgpu/types': 0.1.64
+      '@xmldom/xmldom': 0.8.10
+      earcut: 2.2.4
+      eventemitter3: 5.0.1
+      gifuct-js: 2.1.2
+      ismobilejs: 1.1.1
+      parse-svg-path: 0.1.2
 
   pkg-dir@4.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ catalog:
   "@types/lodash.merge": ^4.6.9
   "@types/mdast": ^4.0.4
   "@types/node": ^20.17.24
-  "@types/obsidian-typings": npm:obsidian-typings@^2.35.0
+  "@types/obsidian-typings": npm:obsidian-typings@^3.12.1
   "@types/semver": ^7.7.0
   "@types/sortablejs": ^1.15.8
   "@types/unist": ^3.0.3


### PR DESCRIPTION
Exposes entity generation functions in the [API](./packages/obsidian/src/api.ts):

* `availableEntityTypes`: get a list of available entity types and their "descriptors" for a campaign
* `getEntityDescriptor`: get an entity descriptor by key
* `promptForEntityType`: prompts the user for an entity type and returns the descriptor
* `generateEntity`: presents the entity creation modal for the given entity descriptor