### PR TITLE
Add oracle prompts to moves that don't roll on stats or progress

### DIFF
--- a/packages/obsidian/src/mechanics/node-builders/index.ts
+++ b/packages/obsidian/src/mechanics/node-builders/index.ts
@@ -5,6 +5,7 @@ import { RollWrapper } from "model/rolls";
 import {
   ActionMoveDescription,
   MoveDescription,
+  moveHasOracles,
   moveIsAction,
   moveIsProgress,
 } from "moves/desc";
@@ -205,6 +206,16 @@ export function generateMechanicsNode(move: MoveDescription): kdl.Document {
           score: Math.floor(move.progressTicks / 4),
           vs1: move.challenge1,
           vs2: move.challenge2,
+        },
+      }),
+    );
+  } else if (moveHasOracles(move)) {
+    children.push(
+      node("oracle", {
+        properties: {
+          name: move.oracleName,
+          roll: move.oracleValue,
+          result: move.oracleResult,
         },
       }),
     );

--- a/packages/obsidian/src/moves/action/index.ts
+++ b/packages/obsidian/src/moves/action/index.ts
@@ -48,6 +48,7 @@ import { CustomSuggestModal } from "../../utils/suggest";
 import {
   ActionMoveAdd,
   NoRollMoveDescription,
+  NoRollOracleMoveDescription,
   type ActionMoveDescription,
   type MoveDescription,
   type ProgressMoveDescription,
@@ -55,6 +56,13 @@ import {
 import { ActionMoveWrapper } from "../wrapper";
 import { checkForMomentumBurn } from "./action-modal";
 import { AddsModal } from "./adds-modal";
+import { createDataswornMarkdownLink } from "../../datastore/parsers/datasworn/id";
+import { RollContext } from "../../model/oracle";
+import { RollWrapper } from "../../model/rolls";
+import { rollOracle } from "../../oracles/command";
+import { OracleRollerModal } from "../../oracles/modal";
+import { NewOracleRollerModal } from "../../oracles/new-modal";
+import { oracleNameWithParents } from "../../oracles/render";
 
 const logger = rootLogger.getLogger("moves");
 
@@ -360,7 +368,7 @@ export async function runMoveCommand(
         break;
       }
       case "no_roll":
-        moveDescription = createEmptyMoveDescription(move);
+        moveDescription = await handleNoRoll(plugin, context, move);
         break;
       case "special_track":
       default:
@@ -384,6 +392,90 @@ export async function runMoveCommand(
       generateMechanicsNode(moveDescription),
     );
   }
+}
+
+async function handleNoRoll(
+  plugin: IronVaultPlugin,
+  context: ActionContext,
+  move: Datasworn.MoveNoRoll | Datasworn.EmbeddedNoRollMove,
+): Promise<MoveDescription> {
+  const noRollMove = move as Datasworn.MoveNoRoll;
+  const oraclesCount = Object.keys(noRollMove.oracles ?? []).length;
+
+  if (oraclesCount > 0) {
+    // move has oracles, let's roll on those
+    const oracleRoll = await handleNoRollOracleMove(
+      plugin,
+      context,
+      noRollMove,
+    );
+
+    if (oracleRoll !== undefined) {
+      const oracleName = createDataswornMarkdownLink(
+        oracleNameWithParents(oracleRoll.oracle),
+        oracleRoll.oracle.id,
+      );
+
+      return {
+        id: move._id,
+        name: move.name,
+        oracleName: oracleName,
+        oracleValue: oracleRoll.diceValue,
+        oracleResult: oracleRoll.simpleResult,
+      } satisfies NoRollOracleMoveDescription;
+    }
+  }
+
+  // move either has no oracles, or rolling on them was skipped
+  return createEmptyMoveDescription(move);
+}
+
+async function handleNoRollOracleMove(
+  plugin: IronVaultPlugin,
+  context: ActionContext,
+  move: Datasworn.MoveNoRoll,
+): Promise<RollWrapper | undefined> {
+  if (move.oracles === undefined) {
+    logger.warn("Move should have oracles but doesn't", move);
+    return Promise.resolve(undefined);
+  }
+
+  const oracles = Object.values<Datasworn.EmbeddedOracleRollable>(move.oracles);
+
+  const choice =
+    await CustomSuggestModal.select<Datasworn.EmbeddedOracleRollable | null>(
+      plugin.app,
+      [...oracles, null],
+      (oracle) => (oracle === null ? "Skip rolling on oracle" : oracle.name),
+      undefined,
+      "Select oracle",
+    );
+
+  if (choice == null) {
+    // "Skip rolling on oracle" was chosen, abort
+    return Promise.resolve(undefined);
+  }
+
+  const rollContext: RollContext = context.campaignContext.oracleRoller;
+  const oracle = rollContext.lookup(choice._id);
+
+  if (oracle === undefined) {
+    logger.warn("Failed to look up oracle id '%s'", choice._id);
+    return Promise.resolve(undefined);
+  }
+
+  const modal = plugin.settings.useLegacyRoller
+    ? OracleRollerModal
+    : NewOracleRollerModal;
+  // only take the roll itself, moves don't consider the cursed die, and we don't have use for the modifiers here
+  const { roll } = await modal.forRoll(
+    plugin,
+    oracle,
+    rollContext,
+    await rollOracle(plugin, rollContext, oracle),
+  );
+
+  return roll;
 }
 
 function createEmptyMoveDescription(

--- a/packages/obsidian/src/moves/desc.ts
+++ b/packages/obsidian/src/moves/desc.ts
@@ -61,6 +61,18 @@ export const NoRollMoveDescriptionSchema = z.object({
 
 export type NoRollMoveDescription = z.infer<typeof NoRollMoveDescriptionSchema>;
 
+export const NoRollOracleMoveDescriptionSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  oracleName: z.string(),
+  oracleValue: z.number(),
+  oracleResult: z.string(),
+});
+
+export type NoRollOracleMoveDescription = z.infer<
+  typeof NoRollOracleMoveDescriptionSchema
+>;
+
 export const AllMoveDescriptionSchemas = z.union([
   ActionMoveDescriptionSchemaV2,
   ProgressMoveDescriptionSchema,
@@ -74,6 +86,7 @@ export const MoveDescriptionSchema = z.union([
   ActionMoveDescriptionSchemaV2,
   ProgressMoveDescriptionSchema,
   NoRollMoveDescriptionSchema,
+  NoRollOracleMoveDescriptionSchema,
 ]);
 
 export type MoveDescription = z.infer<typeof MoveDescriptionSchema>;

--- a/packages/obsidian/src/moves/desc.ts
+++ b/packages/obsidian/src/moves/desc.ts
@@ -101,3 +101,9 @@ export function moveIsProgress(
 ): move is ProgressMoveDescription {
   return (move as ProgressMoveDescription).progressTrack !== undefined;
 }
+
+export function moveHasOracles(
+  move: MoveDescription,
+): move is NoRollOracleMoveDescription {
+  return (move as NoRollOracleMoveDescription).oracleResult !== undefined;
+}

--- a/packages/obsidian/src/oracles/command.ts
+++ b/packages/obsidian/src/oracles/command.ts
@@ -11,7 +11,12 @@ import IronVaultPlugin from "index";
 import { rootLogger } from "logger";
 import { createOrAppendMechanics, insertInlineOracle } from "mechanics/editor";
 import { createOracleNode } from "mechanics/node-builders";
-import { Oracle, OracleGrouping, OracleGroupingType } from "../model/oracle";
+import {
+  Oracle,
+  OracleGrouping,
+  OracleGroupingType,
+  RollContext,
+} from "../model/oracle";
 import { Roll } from "../model/rolls";
 import { CustomSuggestModal } from "../utils/suggest";
 import { OracleRollerModal } from "./modal";
@@ -96,24 +101,7 @@ export async function runOracleCommand(
     );
   }
   const rollContext = new OracleRoller(plugin, campaignContext.oracles);
-
-  // If user wishes to make their own roll, prompt them now.
-  let initialRoll: Roll | undefined = undefined;
-  if (plugin.settings.promptForRollsInOracles) {
-    const diceValue = await CustomSuggestModal.select(
-      plugin.app,
-      [
-        "Roll for me",
-        ...numberRange(oracle.dice.minRoll(), oracle.dice.maxRoll()),
-      ],
-      (x) => x.toString(),
-      undefined,
-      `Roll your oracle dice (${oracle.dice}) and enter the value`,
-    );
-    if (typeof diceValue === "number") {
-      initialRoll = oracle.evaluate(rollContext, diceValue);
-    }
-  }
+  const rollResult = await rollOracle(plugin, rollContext, oracle);
 
   const modal = plugin.settings.useLegacyRoller
     ? OracleRollerModal
@@ -122,7 +110,7 @@ export async function runOracleCommand(
     plugin,
     oracle,
     rollContext,
-    initialRoll || (await oracle.roll(rollContext)),
+    rollResult,
     { shiftActionLabel: "copy result" },
   );
 
@@ -145,4 +133,33 @@ export async function runOracleCommand(
       ]);
     }
   }
+}
+
+export async function rollOracle(
+  plugin: IronVaultPlugin,
+  rollContext: RollContext,
+  oracle: Oracle,
+): Promise<Roll> {
+  // If user wishes to make their own roll, prompt them now.
+  let initialRoll: Roll | undefined = undefined;
+  if (plugin.settings.promptForRollsInOracles) {
+    const diceValue = await CustomSuggestModal.select(
+      plugin.app,
+      [
+        "Roll for me",
+        ...numberRange(oracle.dice.minRoll(), oracle.dice.maxRoll()),
+      ],
+      (x) => x.toString(),
+      undefined,
+      `Roll your oracle dice (${oracle.dice}) and enter the value`,
+    );
+    if (typeof diceValue === "number") {
+      initialRoll = oracle.evaluate(rollContext, diceValue);
+    }
+  }
+
+  if (initialRoll !== undefined) {
+    return Promise.resolve(initialRoll);
+  }
+  return oracle.roll(rollContext);
 }


### PR DESCRIPTION
There are a few moves that don't roll on stats or a progress track, but that have an oracle attached to it, e.g.
- Ask the Oracle
- Pay the Price
- Find an Opportunity (Delve)
- Confront Chaos (SF/SI)

Currently, using the "Make a move" command or the "Make this move with prompts" button in the Moves sidebar creates just an empty move node for those. Thought it would be nice to have the oracle involved directly with the move, so this change here adds a prompt to roll on the attached oracle(s) and add the result to the move nodes, turning it from
<img width="476" height="257" alt="image" src="https://github.com/user-attachments/assets/0c0b5ced-db05-496d-952e-0a701183c95f" />
to
<img width="483" height="431" alt="image" src="https://github.com/user-attachments/assets/1b2f5a0c-8bed-4009-8957-67245ea45015" />

The prompt for "Ask the Oracle" looks for example like this then:
<img width="714" height="289" alt="image" src="https://github.com/user-attachments/assets/ddf854b4-c096-4c82-885d-a4dbea2528d2" />
which then triggers the matching oracle popup - or not, if "Skip rolling on oracle" is selected, in which case an empty move node is added, just like before.

Note that this only affects moves that don't have any stats or progress track attached to, so "Endure Stress" / "Endure Harm" as example, which lets you roll on stats but also roll on an oracle to interpret the outcome, won't be affected by this change.