### PR TITLE
Handle rulesets without rollable entity kinds in Generate Entity command

### DIFF
--- a/packages/obsidian/src/entity/command.test.ts
+++ b/packages/obsidian/src/entity/command.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { determineCampaignContextMock, noticeMock, selectMock } = vi.hoisted(
+  () => ({
+    determineCampaignContextMock: vi.fn(),
+    noticeMock: vi.fn(),
+    selectMock: vi.fn(),
+  }),
+);
+
+vi.mock("campaigns/manager", () => ({
+  determineCampaignContext: determineCampaignContextMock,
+}));
+
+vi.mock("obsidian", () => ({
+  MarkdownRenderer: { render: vi.fn() },
+  MarkdownRenderChild: class {},
+  Notice: noticeMock,
+}));
+
+vi.mock("../utils/suggest", () => ({
+  CustomSuggestModal: { select: selectMock },
+}));
+
+import { generateEntityCommand } from "./command";
+
+describe("generateEntityCommand", () => {
+  beforeEach(() => {
+    determineCampaignContextMock.mockReset();
+    noticeMock.mockReset();
+    selectMock.mockReset();
+  });
+
+  it("shows a notice instead of opening an empty entity picker", async () => {
+    determineCampaignContextMock.mockResolvedValue({
+      oracles: new Map(),
+      rulesPackages: new Map(),
+    });
+
+    await generateEntityCommand({} as never, {} as never, {} as never);
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(noticeMock).toHaveBeenCalledWith(
+      "No rollable entity types are available for the active ruleset. Entity generation may not be supported for Ironsworn Classic yet.",
+    );
+  });
+});

--- a/packages/obsidian/src/entity/command.ts
+++ b/packages/obsidian/src/entity/command.ts
@@ -197,6 +197,16 @@ export async function generateEntityCommand(
 ): Promise<void> {
   const campaignContext = await determineCampaignContext(plugin, view);
 
+  if (!selectedEntityDescriptor) {
+    const entityTypes = availableEntityTypes(campaignContext);
+    if (entityTypes.length === 0) {
+      new Notice(
+        "No rollable entity types are available for the active ruleset. Entity generation may not be supported for Ironsworn Classic yet.",
+      );
+      return;
+    }
+  }
+
   const entityDesc: EntityDescriptor<EntitySpec> =
     selectedEntityDescriptor ??
     (await promptForEntityType(plugin, campaignContext));


### PR DESCRIPTION
## Summary
- Prevent `Generate an entity` from opening the entity type picker when the active campaign has no available entity descriptors
- Show a friendly Obsidian Notice for rulesets without rollable entity types, such as Ironsworn Classic in this path
- Add a focused test covering the empty entity type list behavior

## Notes
This keeps the scope defensive: it does not add new Ironsworn Classic entity generation data.

Fixes/mitigates #537 and #651.

## Testing
- Not run locally: `pnpm`/`corepack` are not available on this Windows desktop session
