### PR TITLE
Render ability names in asset cards

### DIFF
--- a/packages/obsidian/src/assets/asset-card.ts
+++ b/packages/obsidian/src/assets/asset-card.ts
@@ -217,7 +217,12 @@ function renderAssetAbility(
         ?checked=${ability.enabled}
         @click=${toggleAbility}
       />
-      <span>${md(plugin, ability.text)}</span>
+      <span>
+        ${ability.name
+          ? html`<span class="asset-ability-name">${ability.name}:</span>`
+          : ""}
+        ${md(plugin, ability.text)}
+      </span>
     </label>
     ${ability.controls
       ? html`<ul class="controls">

--- a/packages/obsidian/src/assets/css/asset-card.css
+++ b/packages/obsidian/src/assets/css/asset-card.css
@@ -128,6 +128,14 @@
       display: flex;
       flex-flow: row nowrap;
       align-items: flex-start !important;
+      & .asset-ability-name {
+        font-weight: var(--font-extrabold);
+      }
+      & > span,
+      & > span .markdown-wrapper,
+      & > span .markdown-wrapper p {
+        display: inline;
+      }
     }
     & .markdown-wrapper ul {
       list-style: square;


### PR DESCRIPTION
The OG Ironsworn companion assets all have a `name` property in the datasworn JSON data that is currently not rendered at all in the asset cards.

Changing things from
<img width="311" height="414" alt="image" src="https://github.com/user-attachments/assets/c9d811b2-983b-4091-9f9b-84dde95cea7d" />

to
<img width="311" height="424" alt="image" src="https://github.com/user-attachments/assets/05b7a3bf-23f5-4b6c-a62f-0cf173a07967" />
