### PR TITLE
Fix names for Ironsworn character oracles

### DIFF
--- a/packages/obsidian/src/entity/specs.ts
+++ b/packages/obsidian/src/entity/specs.ts
@@ -401,17 +401,12 @@ export const ENTITIES: Record<string, EntityDescriptor<EntitySpec>> = {
   isIronlander: {
     collectionId: "oracle_collection:classic/character",
     label: "Ironlander",
-    nameGen: (ent) => ent.nameA[0]?.simpleResult ?? ent.nameB[0]?.simpleResult,
+    nameGen: (ent) => ent.name[0]?.simpleResult,
     spec: {
-      nameA: {
-        id: "oracle_rollable:classic/name/ironlander/a",
-        name: "Name table A",
+      name: {
+        id: "oracle_rollable:classic/name/ironlander",
+        name: "Character name",
         firstLook: true,
-      },
-      nameB: {
-        id: "oracle_rollable:classic/name/ironlander/b",
-        name: "Name table B",
-        firstLook: false,
       },
       role: {
         id: "oracle_rollable:classic/character/role",


### PR DESCRIPTION
The old Datasworn format had the 200 name character oracle list split up in an "a" and "b" table, but the current Datasworn format supports a single 1d200 table for that. Adapting the Roll All entity definition to a single name list, fixing errors in the popup.

Before:
<img width="570" height="507" alt="image" src="https://github.com/user-attachments/assets/bc5cdf7c-19c4-4c04-8b2d-6334218182be" />
with the "Roll first look" not doing anything

After:
<img width="570" height="507" alt="image" src="https://github.com/user-attachments/assets/c54467cd-fb3b-4a68-bccf-881410ece639" />

Fixes #650 