### PR TITLE
Use previsouly selected playset as base for custom definition

### DIFF
--- a/packages/obsidian/src/campaigns/ui/playset-editor.ts
+++ b/packages/obsidian/src/campaigns/ui/playset-editor.ts
@@ -131,7 +131,9 @@ export class PlaysetEditor extends Modal {
           this.currentPlaysetChoice = playsetChoice;
           // Make the editor reflect this config
           if (this.currentPlaysetChoice == "custom") {
-            this.configEditorEl.value = this.customConfig;
+            if (this.customConfig) {
+              this.configEditorEl.value = this.customConfig;
+            } // else use the currently selected standard playset as base
             this.configEditorEl.disabled = false;
           } else {
             this.configEditorEl.value =


### PR DESCRIPTION
If one of the standard playsets is selected in the "Choose playset" modal's dropdown menu when configuring the playset of a new campaign, switching to "Custom playset" is now keeping the previous content in the text box instead of clearing it. The idea is to make it easier to extend the standard playsets with additional own content (i.e., no need to copy & paste things around)