### PR TITLE
Fix: Ironclad asset Equipped status doesn't stick

### DIFF
--- a/packages/obsidian/src/assets/asset-card.ts
+++ b/packages/obsidian/src/assets/asset-card.ts
@@ -386,7 +386,7 @@ function renderControl<C extends AssetControlField | AssetAbilityControlField>(
         <select
           ?disabled=${!updateControl}
           .value=${control.value}
-          @click=${updateControlValue}
+          @change=${updateControlValue}
         >
           <option ?selected=${control.value == null}></option>
           ${map(Object.entries(control.choices), ([key, choice]) =>


### PR DESCRIPTION
This fixes #635 

Previously, as soon as you left the character note, the choice you made would disappear, but now it stores whatever you choose to wear even if you leave and come back.
