### PR TITLE
Ignore legacy track XP in classic ruleset

### DIFF
--- a/packages/obsidian/src/characters/character-block.ts
+++ b/packages/obsidian/src/characters/character-block.ts
@@ -170,6 +170,14 @@ class CharacterRenderer extends TrackedEntityRenderer<
         );
       };
     };
+    const legacyTrackXp = () => {
+      if (!lens.ruleset.gainXpFromLegacyTracks) {
+        return 0;
+      }
+      return Object.values(lens.special_tracks).reduce((acc, track) => {
+        return acc + legacyTrackXpEarned(track.get(raw));
+      }, 0);
+    };
     const campaignContext = this.campaignContext();
     return html`<section class="character-info">
       <header class="name">
@@ -260,11 +268,7 @@ class CharacterRenderer extends TrackedEntityRenderer<
           />
         </dd>
         <dt>XP From Tracks</dt>
-        <dd class="xp-from-tracks">
-          ${Object.values(lens.special_tracks).reduce((acc, track) => {
-            return acc + legacyTrackXpEarned(track.get(raw));
-          }, 0)}
-        </dd>
+        <dd class="xp-from-tracks">${legacyTrackXp()}</dd>
         <dt>XP added</dt>
         <dd class="xp-added">
           <input
@@ -275,10 +279,7 @@ class CharacterRenderer extends TrackedEntityRenderer<
         </dd>
         <dt>Total XP earned</dt>
         <dd class="xp-earned">
-          ${(lens.xp_added.get(raw) ?? 0) +
-          Object.values(lens.special_tracks).reduce((acc, track) => {
-            return acc + legacyTrackXpEarned(track.get(raw));
-          }, 0)}
+          ${(lens.xp_added.get(raw) ?? 0) + legacyTrackXp()}
         </dd>
         <dt>XP spent</dt>
         <dd class="xp-spent">
@@ -471,7 +472,9 @@ class CharacterRenderer extends TrackedEntityRenderer<
                 },
                 updateTrack.bind(undefined, value),
                 false,
-                legacyTrackXpEarned(value.get(raw)),
+                lens.ruleset.gainXpFromLegacyTracks
+                  ? legacyTrackXpEarned(value.get(raw))
+                  : undefined,
               )}
             </li>
           `,

--- a/packages/obsidian/src/characters/lens.ts
+++ b/packages/obsidian/src/characters/lens.ts
@@ -107,7 +107,7 @@ function camelCase(str: string): string {
     .join("");
 }
 
-function legacyTrack(specialTrackRule: SpecialTrackRule) {
+function legacyTrack(specialTrackRule: SpecialTrackRule, gainXp: boolean) {
   const formattedLabel = camelCase(specialTrackRule.label);
   const progressKey = `${formattedLabel}_Progress`;
   const xpEarnedKey = `${formattedLabel}_XPEarned`;
@@ -131,7 +131,7 @@ function legacyTrack(specialTrackRule: SpecialTrackRule) {
         const orig = this.get(source);
 
         if (orig.progress === newval.progress) return source;
-        if (legacyTrackXpEarned(orig) !== source[xpEarnedKey]) {
+        if (gainXp && legacyTrackXpEarned(orig) !== source[xpEarnedKey]) {
           throw new Error(
             `unexpected XP amount ${source[xpEarnedKey]} for track with ${source[progressKey]} progress (expected: ${legacyTrackXpEarned(orig)})`,
           );
@@ -139,7 +139,7 @@ function legacyTrack(specialTrackRule: SpecialTrackRule) {
         return {
           ...source,
           [progressKey]: newval.progress,
-          [xpEarnedKey]: legacyTrackXpEarned(newval),
+          [xpEarnedKey]: gainXp ? legacyTrackXpEarned(newval) : 0,
         };
       },
     } satisfies Lens<Record<string, unknown>, ProgressTrack>,
@@ -489,7 +489,7 @@ export function characterLens(ruleset: Ruleset): {
     path: key,
   }));
   const specialTracks = objectMap(ruleset.special_tracks, (rule) =>
-    legacyTrack(rule),
+    legacyTrack(rule, ruleset.gainXpFromLegacyTracks),
   );
   const schema = baseIronVaultSchema.extend({
     ...objectMap(stats, ({ schema }) => schema),

--- a/packages/obsidian/src/rules/ruleset.ts
+++ b/packages/obsidian/src/rules/ruleset.ts
@@ -199,4 +199,11 @@ export class Ruleset {
   get baseRulesetId(): string {
     return this.rulesPackageIds[0];
   }
+
+  get gainXpFromLegacyTracks(): boolean {
+    // Classic Ironsworn doesn't award XP from legacy tracks, only Starforged.
+    // Unfortunately, there's no value in Datasworn to determine that,
+    // so for now we're just checking if the ruleset is "classic" or not.
+    return this.baseRulesetId !== "classic";
+  }
 }


### PR DESCRIPTION
Classic Ironsworn doesn't award XP for legacy track progress like Starforged does. Ignore legacy tracks when counting total XP and don't render the XP value above them in the character sheet.

Before:
<img width="560" height="227" alt="image" src="https://github.com/user-attachments/assets/0062b191-b3bc-4d3c-9c44-b33e0425ba45" />
<img width="417" height="160" alt="image" src="https://github.com/user-attachments/assets/5cd947d3-94a6-44b6-a501-f45ff9b1abfa" />

After:
<img width="513" height="213" alt="image" src="https://github.com/user-attachments/assets/ff3e23d0-6935-491d-9d89-5c3419e0d5f5" />
<img width="417" height="160" alt="image" src="https://github.com/user-attachments/assets/ea18222a-4582-40bf-95bd-45bf4d5d05e1" />


Unfortunately there's no "legacy tracks award XP" flag in Datasworn, so as a start, I'm simply hardcoding that "classic" ruleset doesn't and all else does.