### PR TITLE
Handle special_track move rolls

### DIFF
--- a/packages/obsidian/src/moves/action/index.ts
+++ b/packages/obsidian/src/moves/action/index.ts
@@ -283,7 +283,11 @@ async function processActionMove(
 }
 
 async function processProgressMove(
-  move: Datasworn.MoveProgressRoll | Datasworn.EmbeddedProgressRollMove,
+  move:
+    | Datasworn.MoveProgressRoll
+    | Datasworn.EmbeddedProgressRollMove
+    | Datasworn.MoveSpecialTrack
+    | Datasworn.EmbeddedSpecialTrackMove,
   tracker: ProgressTrackWriterContext,
   diceRoller: AsyncDiceRoller,
   roll?: { challenge1: number; challenge2: number },
@@ -371,13 +375,16 @@ export async function runMoveCommand(
         moveDescription = await handleNoRoll(plugin, context, move);
         break;
       case "special_track":
-      default:
-        // TODO: this probably makes sense with new mechanics format?
-        logger.warn(
-          "Teach me how to handle a move with roll type %s: %o",
-          move.roll_type,
+        moveDescription = await handleSpecialTrackRoll(
+          plugin,
+          diceRoller,
+          new ProgressContext(plugin, context),
           move,
         );
+        break;
+      default:
+        // Shouldn't happen unless move.roll_type was extended and forgotten to handle here
+        logger.warn("Unhandled move type: %o", move);
         moveDescription = createEmptyMoveDescription(move);
     }
   }
@@ -501,6 +508,30 @@ async function handleProgressRoll(
       !prog.track.complete,
   );
 
+  const rolls = await promptForChallengeDiceRolls(plugin);
+
+  // TODO: when would we mark complete? should we prompt on a hit?
+  return await processProgressMove(move, progressTrack, diceRoller, rolls);
+}
+
+async function handleSpecialTrackRoll(
+  plugin: IronVaultPlugin,
+  diceRoller: AsyncDiceRoller,
+  context: ProgressContext,
+  move: Datasworn.MoveSpecialTrack | Datasworn.EmbeddedSpecialTrackMove,
+): Promise<MoveDescription> {
+  const progressTrack = await selectProgressTrack(
+    context,
+    plugin,
+    (prog) => prog.trackType === "Legacy",
+  );
+
+  const rolls = await promptForChallengeDiceRolls(plugin);
+
+  return await processProgressMove(move, progressTrack, diceRoller, rolls);
+}
+
+async function promptForChallengeDiceRolls(plugin: IronVaultPlugin) {
   let rolls: { challenge1: number; challenge2: number } | undefined;
   if (plugin.settings.promptForRollsInMoves) {
     const challenge1 = await CustomSuggestModal.select(
@@ -522,9 +553,7 @@ async function handleProgressRoll(
       rolls = { challenge1, challenge2 };
     }
   }
-
-  // TODO: when would we mark complete? should we prompt on a hit?
-  return await processProgressMove(move, progressTrack, diceRoller, rolls);
+  return rolls;
 }
 
 const ORDINALS = [


### PR DESCRIPTION
Handling moves rolling against the legacy tracks:
 - Write Your Epilogue (IS)
 - Learn From Your Failures (Delve)
 - Overcome Destruction (SF/SI)
 - Continue a Legacy (SF/SI)

They're technically progress rolls, so overall handling them just like any other progress roll, but limit the options in the track selection modal to only the legacy tracks.

Before:
<img width="478" height="182" alt="image" src="https://github.com/user-attachments/assets/0359f111-a7bd-45b4-8c01-869896fc740f" />

After:
<img width="477" height="253" alt="image" src="https://github.com/user-attachments/assets/3a49af13-ace2-475b-bc2c-ae7465f00a5c" />
with modal
<img width="714" height="257" alt="image" src="https://github.com/user-attachments/assets/46991080-5c36-4250-9714-29e8d624a31b" />
